### PR TITLE
Feature/global toc

### DIFF
--- a/otterwiki/templates/global_toc.html
+++ b/otterwiki/templates/global_toc.html
@@ -1,0 +1,14 @@
+{# vim: set et ts=8 sts=4 sw=4 ai: #}
+{% extends "wiki.html" %}
+{% block content %}
+<h2>{{ title }}</h2>
+<div class="container-lg">
+{% for depth, title in pages%}
+<div class="row">
+    <div class="col-xl-2 col-lg-3 col-md-6 pl-{{ depth*10 }}">
+        <a class="sidebar-link sidebar-toc-{{ depth }} pl-5" href="{{ url_for('view', path=title ) }}">{{title | title}}</a>
+    </div>
+</div>
+{% endfor %}
+</div>
+{% endblock %}

--- a/otterwiki/views.py
+++ b/otterwiki/views.py
@@ -11,7 +11,7 @@ from flask import (
     make_response,
 )
 from otterwiki.server import app, db
-from otterwiki.wiki import Page, PageIndex, Changelog, Search, render
+from otterwiki.wiki import Page, PageIndex, WikiToc, Changelog, Search, render
 import otterwiki.auth
 import otterwiki.preferences
 from otterwiki.helper import toast
@@ -108,6 +108,10 @@ def pageindex():
     idx = PageIndex("/")
     return idx.render()
 
+@app.route("/-/toc")
+def toc():
+    idx = WikiToc("/")
+    return idx.render()
 
 @app.route("/-/create", methods=["POST", "GET"])
 def create():

--- a/otterwiki/wiki.py
+++ b/otterwiki/wiki.py
@@ -78,6 +78,22 @@ class PageIndex:
             pages=self.pages,
         )
 
+class WikiToc:
+    def __init__(self, path=None):
+        '''
+        This will generate a TOC from a given path. Path is not yet implemented. But, the idea is that you could,
+        for instance, create a feature where a toc could be automatically generated for a complicated sub folder.
+        '''
+        self.toc = storage.toc(p=None, depth=1)
+
+    def render(self):
+        if not has_permission("READ"):
+            abort(403)
+        return render_template(
+            "global_toc.html",
+            title="Table of Contents",
+            pages=self.toc,
+        )
 
 class Changelog:
     def __init__(self, commit_start=None):


### PR DESCRIPTION
This adds functionality to add a global Table of Contents. I think this will be helpful when sub folders are implemented to get a full hierarchy. I did not add any link for this (say, on the side bar). I'll let you decide if you want the feature, and how to link it. To access it, go to `/-/toc`