### PR TITLE
Fixes #85 - adds support for case sensitive page names

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -36,7 +36,7 @@ for EV in READ_ACCESS WRITE_ACCESS ATTACHMENT_ACCESS; do
         echo "${EV} = '${!EV}'" >> ${OTTERWIKI_SETTINGS}
     fi
 done
-for EV in AUTO_APPROVAL EMAIL_NEEDS_CONFIRMATION; do
+for EV in AUTO_APPROVAL EMAIL_NEEDS_CONFIRMATION RAW_PAGE_NAMES; do
     if [ ! -z "${!EV}" ]; then
         sed -i "/^${EV}.*/d" ${OTTERWIKI_SETTINGS}
         echo "${EV} = ${!EV}" >> ${OTTERWIKI_SETTINGS}

--- a/otterwiki/helper.py
+++ b/otterwiki/helper.py
@@ -101,19 +101,30 @@ def health_check():
         return True, ["ok"]
     return False, msg
 
-def auto_url(filename, revision=None):
+
+def auto_url(filename, revision=None, raw_page_names=False):
     # handle attachments and pages
     arr = split_path(filename)
     if filename.endswith(".md"):
         # page
-        return (get_pagename(filename, full=True),
-                url_for(
-                    "view", path=get_pagename(filename, full=True),
-                    revision=revision
-               ))
+        return (
+            get_pagename(filename, full=True, raw_page_names=raw_page_names),
+            url_for(
+                "view",
+                path=get_pagename(
+                    filename, full=True, raw_page_names=raw_page_names
+                ),
+                revision=revision,
+            ),
+        )
     else:
         # attachment
-        pagename, attached_filename = get_pagename(join_path(arr[:-1]), full=True), arr[-1]
+        pagename, attached_filename = (
+            get_pagename(
+                join_path(arr[:-1]), full=True, raw_page_names=raw_page_names
+            ),
+            arr[-1],
+        )
         return (filename,
                 url_for('get_attachment',
                     pagepath=pagename,

--- a/otterwiki/preferences.py
+++ b/otterwiki/preferences.py
@@ -77,8 +77,13 @@ def handle_app_preferences(form):
         _update_preference(name.upper(),form.get(name, ""))
     for name in ["READ_access", "WRITE_access", "ATTACHMENT_access"]:
         _update_preference(name.upper(),form.get(name, "ANONYMOUS"))
-    for checkbox in ["auto_approval", "email_needs_confirmation",
-                     "notify_admins_on_register", "notify_user_on_approval"]:
+    for checkbox in [
+        "auto_approval",
+        "email_needs_confirmation",
+        "notify_admins_on_register",
+        "notify_user_on_approval",
+        "raw_page_names",
+    ]:
         _update_preference(checkbox.upper(),form.get(checkbox, "False"))
     # commit changes to the database
     db.session.commit()

--- a/otterwiki/server.py
+++ b/otterwiki/server.py
@@ -29,6 +29,7 @@ app.config.update(
     EMAIL_NEEDS_CONFIRMATION=True,
     NOTIFY_ADMINS_ON_REGISTER=False,
     NOTIFY_USER_ON_APPROVAL=False,
+    RAW_PAGE_NAMES=False,
     SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
     MAIL_DEFAULT_SENDER="otterwiki@YOUR.ORGANIZATION.TLD",
     MAIL_SERVER="",
@@ -100,9 +101,15 @@ def update_app_config():
     global mail
     with app.app_context():
         for item in Preferences.query:
-            if item.name.upper() in ["MAIL_USE_TLS", "MAIL_USE_SSL", "AUTO_APPROVAL",
-                                     "EMAIL_NEEDS_CONFIRMATION", "NOTIFY_ADMINS_ON_REGISTER",
-                                     "NOTIFY_USER_ON_APPROVAL"]:
+            if item.name.upper() in [
+                "MAIL_USE_TLS",
+                "MAIL_USE_SSL",
+                "AUTO_APPROVAL",
+                "EMAIL_NEEDS_CONFIRMATION",
+                "NOTIFY_ADMINS_ON_REGISTER",
+                "NOTIFY_USER_ON_APPROVAL",
+                "RAW_PAGE_NAMES",
+            ]:
                 item.value = item.value.lower() in ["true","yes"]
             if item.name.upper() in ["MAIL_PORT"]:
                 try:

--- a/otterwiki/sidebar.py
+++ b/otterwiki/sidebar.py
@@ -19,7 +19,7 @@ class SidebarNavigation:
     SETEX_HEADING = re.compile(r'([^\n]+)\n *(=|-){2,}[ \t]*\n+')
 
     def __init__(self, path: str = "/"):
-        self.path = path.lower()
+        self.path = path if app.config["RAW_PAGE_NAMES"] else path.lower()
         self.path_depth = len(split_path(self.path))
         try:
             self.max_depth = int(app.config["SIDEBAR_MENUTREE_MAXDEPTH"])
@@ -86,13 +86,16 @@ class SidebarNavigation:
                     join_path(prefix + parts),
                     full=True,
                     header=header if len(parts) == 1 else None,
+                    raw_page_names=app.config["RAW_PAGE_NAMES"],
                 ),
                 "header": get_pagename(
                     join_path(prefix + parts),
                     full=False,
                     header=header if len(parts) == 1 else None,
+                    raw_page_names=app.config["RAW_PAGE_NAMES"],
                 ),
             }
+            print(tree)
         if len(parts) > 1:
             self.add_node(
                 tree[parts[0]]["children"], prefix + [parts[0]], parts[1:]

--- a/otterwiki/templates/admin.html
+++ b/otterwiki/templates/admin.html
@@ -221,6 +221,14 @@ selected="selected"
         </select>
     </div>
 {##}
+    <div class="form-group">
+      <div class="custom-checkbox">
+        <input {%if config.RAW_PAGE_NAMES %}checked{% endif %} type="checkbox" id="raw_page_names" name="raw_page_names"
+          value="True">
+        <label for="raw_page_names">Preserve "raw" page names when saving and displaying markdown files</label>
+      </div>
+    </div>
+{##}
   <div class="mt-10">
     <input class="btn btn-primary" name="update_preferences" type="submit" value="Save Preferences">
   </div>

--- a/otterwiki/util.py
+++ b/otterwiki/util.py
@@ -93,12 +93,12 @@ def split_path(path):
     return split_path(head) + [tail]
 
 
-def get_filename(pagepath):
+def get_filename(pagepath, raw_page_names=False):
     '''This is the actual filepath on disk (not via URL) relative to the repository root
     This function will attempt to determine if this is a 'folder' or a 'page'.
     '''
 
-    p = pagepath.lower()
+    p = pagepath if raw_page_names else pagepath.lower()
     p = clean_slashes(p)
 
     if not p.endswith(".md"):
@@ -107,11 +107,12 @@ def get_filename(pagepath):
     return p
 
 
-def get_attachment_directoryname(filename):
-    filename = filename.lower()
+def get_attachment_directoryname(filename, raw_page_names=False):
+    filename = filename if raw_page_names else filename.lower()
     if filename[-3:] != ".md":
         raise ValueError
     return filename[:-3]
+
 
 def titleSs(s):
     """
@@ -127,7 +128,7 @@ def titleSs(s):
     return s.replace(magicword,'ß')
 
 
-def get_pagename(filepath, full=False, header=None):
+def get_pagename(filepath, full=False, header=None, raw_page_names=False):
     '''This will derive the page name (displayed on the web page) from the url requested'''
     # remove trailing slashes from filepath
     filepath=filepath.rstrip("/")
@@ -145,7 +146,7 @@ def get_pagename(filepath, full=False, header=None):
                 or (hint == part and hint != part.lower()):
             arr[i] = hint
         else:
-            arr[i] = titleSs(part)
+            arr[i] = part if raw_page_names else titleSs(part)
 
     if not full:
         return arr[-1]

--- a/otterwiki/wiki.py
+++ b/otterwiki/wiki.py
@@ -416,7 +416,7 @@ class Page:
             self.pagename = pagename
             self.pagepath = get_pagepath(pagename)
 
-        self.pagename_full = get_pagename(self.pagepath, full=True)
+        self.pagename_full = get_pagename(self.pagepath, full=True, raw_page_names=app.config["RAW_PAGE_NAMES"])
         self.revision = revision
 
         self.filename = get_filename(
@@ -438,10 +438,10 @@ class Page:
         if self.content is not None:
             header = get_header(self.content)
             self.pagename = get_pagename(
-                self.pagepath, full=False, header=header
+                self.pagepath, full=False, header=header, raw_page_names=app.config["RAW_PAGE_NAMES"]
             )
             self.pagename_full = get_pagename(
-                self.pagepath, full=True, header=header
+                self.pagepath, full=True, header=header, raw_page_names=app.config["RAW_PAGE_NAMES"]
             )
 
     def breadcrumbs(self):

--- a/settings.cfg.skeleton
+++ b/settings.cfg.skeleton
@@ -19,6 +19,7 @@ ATTACHMENT_ACCESS = 'REGISTERED'
 AUTO_APPROVAL     = True
 EMAIL_NEEDS_CONFIRMATION = True
 # NOTIFY_ADMINS_ON_REGISTER = True
+# RAW_PAGE_NAMES = True
 
 # Database Configuration
 # e.g. SQLALCHEMY_DATABASE_URI='sqlite:////absolute/path/to/the/sqlite/database/file'

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -101,3 +101,16 @@ def test_auto_url(create_app, req_ctx):
     name, path = otterwiki.helper.auto_url("page/example.mp4")
     assert name == "page/example.mp4"
     assert path == "/Page/a/example.mp4"
+    name, path = otterwiki.helper.auto_url("home.md", raw_page_names=True)
+    assert name == "home"
+    assert path == "/home"
+    name, path = otterwiki.helper.auto_url(
+        "subspace/example.md", raw_page_names=True
+    )
+    assert name == "subspace/example"
+    assert path == "/subspace/example"
+    name, path = otterwiki.helper.auto_url(
+        "page/example.mp4", raw_page_names=True
+    )
+    assert name == "page/example.mp4"
+    assert path == "/page/a/example.mp4"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -98,10 +98,15 @@ def test_get_filename():
     assert get_filename("hOme") == "home.md"
     assert get_filename("Home.md") == "home.md"
     assert get_filename("HOME.MD") == "home.md"
+    assert get_filename("Home", raw_page_names=True) == "Home.md"
+    assert get_filename("hOme", raw_page_names=True) == "hOme.md"
+    assert get_filename("Home.md", raw_page_names=True) == "Home.md"
+    assert get_filename("HOME.MD", raw_page_names=True) == "HOME.MD.md"
 
 
 def test_get_attachment_directoryname():
     assert get_attachment_directoryname("Home.md") == "home"
+    assert get_attachment_directoryname("Home.md", raw_page_names=True) == "Home"
     with pytest.raises(ValueError):
         assert get_attachment_directoryname("Home")
 
@@ -138,6 +143,27 @@ def test_get_pagename():
     assert "Two Words" == get_pagename("subdir1/subdir2/Two Words")
     assert "Subdir/Two words" == get_pagename("subdir/Two words", full=True)
     assert "Two words/Two words" == get_pagename("Two words/Two words", full=True)
+    # testing raw page name functionality
+    assert "example" == get_pagename("subspace/example.md", raw_page_names=True)
+    assert "example" == get_pagename("subspace/example", raw_page_names=True)
+    assert "subspace/example" == get_pagename("subspace/example.md", full=True, raw_page_names=True)
+    assert "subspace/example" == get_pagename("subspace/example", full=True, raw_page_names=True)
+    assert "example" == get_pagename("example.md", raw_page_names=True)
+    assert "example" == get_pagename("example.md", full=True, raw_page_names=True)
+    # updated version wich respects upper and lowercase
+    assert "ExamplE" == get_pagename("ExamplE", raw_page_names=True)
+    assert "two words" == get_pagename("two words.md", raw_page_names=True)
+    assert "two words" == get_pagename("two words", raw_page_names=True)
+    assert "Two words" == get_pagename("Two words", raw_page_names=True)
+    assert "Two words" == get_pagename("two words", header="Two words", raw_page_names=True)
+    # and with subdirectories
+    assert "Two words" == get_pagename("subdir/two words", header="Two words", raw_page_names=True)
+    assert "Two words" == get_pagename("subdir/two words.md", header="Two words", raw_page_names=True)
+    assert "Two words" == get_pagename("subdir1/subdir2/two words.md", header="Two words", raw_page_names=True)
+    assert "two words" == get_pagename("subdir1/subdir2/two words.md", raw_page_names=True)
+    assert "Two Words" == get_pagename("subdir1/subdir2/Two Words", raw_page_names=True)
+    assert "subdir/Two words" == get_pagename("subdir/Two words", full=True, raw_page_names=True)
+    assert "Two words/Two words" == get_pagename("Two words/Two words", full=True, raw_page_names=True)
 
 
 def test_mkdir(tmpdir):


### PR DESCRIPTION
See discussion in #85. This adds the ability for page names to resolve case-sensitively, but only when the `RAW_PAGE_NAMES` configuration option is set.