### PR TITLE
Proof of concept for reverse-proxy auth

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -30,7 +30,7 @@ for EV in SITE_NAME SITE_LOGO SITE_DESCRIPTION SITE_ICON; do
     fi
 done
 # permissions
-for EV in READ_ACCESS WRITE_ACCESS ATTACHMENT_ACCESS; do
+for EV in AUTH_METHOD READ_ACCESS WRITE_ACCESS ATTACHMENT_ACCESS; do
     if [ ! -z "${!EV}" ]; then
         sed -i "/^${EV}.*/d" ${OTTERWIKI_SETTINGS}
         echo "${EV} = '${!EV}'" >> ${OTTERWIKI_SETTINGS}

--- a/docs/auth_examples/header-auth/Caddyfile
+++ b/docs/auth_examples/header-auth/Caddyfile
@@ -1,0 +1,17 @@
+{
+	http_port 8081
+	auto_https off
+	log {
+		format console
+	}
+	servers {
+		log_credentials
+	}
+}
+:8081 {
+	reverse_proxy otterwiki:80 {
+		header_up x-otterwiki-name "Otter Example"
+		header_up x-otterwiki-email "mail@example.com"
+		header_up x-otterwiki-permissions "READ,WRITE,UPLOAD,ADMIN"
+	}
+}

--- a/docs/auth_examples/header-auth/Makefile
+++ b/docs/auth_examples/header-auth/Makefile
@@ -1,5 +1,5 @@
 run:
 	docker compose up --remove-orphans
 
-caddy-fmt
+caddy-fmt:
 	docker run -v $(PWD)/Caddyfile:/srv/Caddyfile:rw caddy:2 caddy fmt --overwrite Caddyfile

--- a/docs/auth_examples/header-auth/Makefile
+++ b/docs/auth_examples/header-auth/Makefile
@@ -1,0 +1,5 @@
+run:
+	docker compose up --remove-orphans
+
+caddy-fmt
+	docker run -v $(PWD)/Caddyfile:/srv/Caddyfile:rw caddy:2 caddy fmt --overwrite Caddyfile

--- a/docs/auth_examples/header-auth/README.md
+++ b/docs/auth_examples/header-auth/README.md
@@ -1,0 +1,18 @@
+# Example for testing `AUTH_METHOD=PROXY_HEADER`
+
+This is a minimal example for testing the `PROXY_HEADER` auth method.
+Here a Caddy sets the headers as if they were configured by an auth
+service.
+
+Usage:
+
+    make run
+
+Testing:
+
+- On <http://localhost:8080> the otterwiki is listening, no header is
+set. The access results in a 403 Forbidden
+- On <http://localhost:8081> a caddy server is listening, which does a
+reverse proxy into the otterwiki service with additional headers
+providing information about the user.
+

--- a/docs/auth_examples/header-auth/docker-compose.yaml
+++ b/docs/auth_examples/header-auth/docker-compose.yaml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+  otterwiki:
+    build: ../../..
+    restart: unless-stopped
+    ports:
+      # forward the http port to 8080
+      - "8080:80"
+    environment:
+      - SITE_NAME=Otter Header Auth
+      - AUTH_METHOD=PROXY_HEADER
+      - READ_ACCESS=APPROVED
+      - WRITE_ACCESS=APPROVED
+      - ATTACHMENT_ACCESS=APPROVED
+  caddy:
+    image: caddy:2
+    container_name: caddy
+    restart: unless-stopped
+    ports:
+      - 8081:8081
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro

--- a/otterwiki/auth.py
+++ b/otterwiki/auth.py
@@ -583,6 +583,7 @@ class ProxyHeaderAuth:
         return [current_user]
 
     def has_permission(self, permission, user):
+        if not user.is_authenticated: return False
         return permission.upper() in user.permissions
 
 

--- a/otterwiki/auth.py
+++ b/otterwiki/auth.py
@@ -263,7 +263,6 @@ class SimpleAuth:
         subject = "New Account Registration - {} - An Otter Wiki".format(app.config["SITE_NAME"])
         send_mail(subject=subject, recipients=admin_emails, text_body=text_body)
 
-
     def _user_needs_approvement(self):
         # check if the user needs to be approved by checking
         # if beeing REGISTERED is a lower requirement anywhere
@@ -288,7 +287,6 @@ class SimpleAuth:
         # notify admins
         if app.config['NOTIFY_ADMINS_ON_REGISTER']:
             self.activated_user_notify_admins(user.name, user.email)
-
 
     def handle_register(self, email, name, password1, password2):
         # check if email exists
@@ -433,24 +431,191 @@ class SimpleAuth:
             toast("Invalid email address.")
         return lost_password_form()
 
+    def has_permission(self, permission, user):
+        if user.is_authenticated and user.is_admin:
+            return True
+        # check page read permission
+        if permission.upper() == "READ":
+            if app.config["READ_ACCESS"].upper() == "ANONYMOUS":
+                return True
+            if (
+                app.config["READ_ACCESS"].upper() == "REGISTERED"
+                and user.is_authenticated
+            ):
+                return True
+            if (
+                app.config["READ_ACCESS"].upper() == "APPROVED"
+                and user.is_authenticated
+                and user.is_approved
+            ):
+                return True
+            if user.is_authenticated and user.is_approved and user.allow_read:
+                return True
+            # admins have permissions for everything
+            if user.is_authenticated and user.is_admin:
+                return True
+        # check page edit permission
+        if permission.upper() == "WRITE":
+            # if you are not allowed to read, you are not allowed to write
+            if not has_permission("READ"):
+                return False
+            if app.config["WRITE_ACCESS"].upper() == "ANONYMOUS":
+                return True
+            if (
+                app.config["WRITE_ACCESS"].upper() == "REGISTERED"
+                and user.is_authenticated
+            ):
+                return True
+            if (
+                app.config["WRITE_ACCESS"].upper() == "APPROVED"
+                and user.is_authenticated
+                and user.is_approved
+            ):
+                return True
+            if user.is_authenticated and user.is_approved and user.allow_write:
+                return True
+            # admins have permissions for everything
+            if user.is_authenticated and user.is_admin:
+                return True
+        # check upload permission
+        if permission.upper() == "UPLOAD":
+            if not has_permission("WRITE"):
+                return False
+            if app.config["ATTACHMENT_ACCESS"] == "ANONYMOUS":
+                return True
+            if (
+                app.config["ATTACHMENT_ACCESS"] == "REGISTERED"
+                and user.is_authenticated
+            ):
+                return True
+            if (
+                app.config["ATTACHMENT_ACCESS"] == "APPROVED"
+                and user.is_authenticated
+                and user.is_approved
+            ):
+                return True
+            if (
+                user.is_authenticated
+                and user.is_approved
+                and user.allow_upload
+            ):
+                return True
+            # admins have permissions for everything
+            if user.is_authenticated and user.is_admin:
+                return True
+        if permission.upper() == "ADMIN":
+            if user.is_anonymous:
+                return False
+            return True == user.is_admin
+
+        return False
+
+    def supported_features(self):
+        return {'passwords': True, 'editing': True, 'logout': True}
+
+
+class ProxyHeaderAuth:
+    # if logout_link is not provided, hide the logout button
+    def __init__(self, logout_link=None):
+        self.logout_link = logout_link
+
+    class User(UserMixin):
+        def __init__(self, name, email, permissions):
+            self.name = name
+            self.email = email
+            self.is_approved = True
+            self.allow_read = 'READ' in permissions
+            self.allow_write = 'WRITE' in permissions
+            self.allow_upload = 'UPLOAD' in permissions
+            self.is_admin = 'ADMIN' in permissions
+            self.permissions = permissions
+
+        def __repr__(self):
+            return f"<User '{self.name} <{self.email}>' a:{self.is_admin}>"
+
+    def supported_features(self):
+        return {'passwords': False, 'editing': False, 'logout': False}
+
+    # called on every page load
+    def request_loader(self, req):
+        if 'x-otterwiki-name' not in req.headers:
+            return None
+
+        if 'x-otterwiki-email' not in req.headers:
+            return None
+
+        if 'x-otterwiki-permissions' in req.headers:
+            permissions = (
+                req.headers.get('x-otterwiki-permissions').upper().split(',')
+            )
+        else:
+            permissions = []
+
+        return self.User(
+            name=req.headers.get('x-otterwiki-name'),
+            email=req.headers.get('x-otterwiki-email'),
+            permissions=permissions,
+        )
+
+    # we can use the same implementation as above
+    def get_author(self):
+        if not current_user.is_authenticated:
+            return ("Anonymous", "")
+        return (current_user.name, current_user.email)
+
+    # user will be directed to login form first, we should redirect them to handle_login automatically (just a POST to /-/login)
+    def login_form(self, *args, **kwargs):
+        if current_user.is_authenticated and self.has_permission(
+            'READ', current_user
+        ):
+            return redirect(url_for("index"))
+        else:
+            return abort(403)
+
+    def settings_form(self):
+        return render_template(
+            "settings.html",
+            title="Settings",
+            user_list=None,  # no users are stored in the database anyways
+        )
+
+    def get_all_user(self):
+        return [current_user]
+
+    def has_permission(self, permission, user):
+        return permission.upper() in user.permissions
+
 
 # create login manager
 login_manager = LoginManager()
 login_manager.init_app(app)
-login_manager.login_view = "login" # pyright: ignore
+login_manager.login_view = "login"  # pyright: ignore
 
 # create auth_manager
 if app.config.get("AUTH_METHOD") in ["", "SIMPLE"]:
     auth_manager = SimpleAuth()
+elif app.config.get("AUTH_METHOD") == "PROXY_HEADER":
+    auth_manager = ProxyHeaderAuth()
 else:
-    raise RuntimeError("Unknown AUTH_METHOD '{}'".format(app.config.get("AUTH_METHOD")))
+    raise RuntimeError(
+        "Unknown AUTH_METHOD '{}'".format(app.config.get("AUTH_METHOD"))
+    )
 
 #
 # proxies
 #
-@login_manager.user_loader
-def user_load_proxy(id):
-    return auth_manager.user_loader(id)
+if hasattr(auth_manager, "user_loader"):
+
+    @login_manager.user_loader
+    def user_load_proxy(id):
+        return auth_manager.user_loader(id)
+
+
+elif hasattr(auth_manager, "request_loader"):
+
+    @login_manager.request_loader
+    def request_load_proxy(req):
+        return auth_manager.request_loader(req)
 
 
 def login_form(*args, **kwargs):
@@ -532,102 +697,14 @@ def check_credentials(email, password):
 # utils
 #
 def has_permission(permission, user=current_user):
-    if user.is_authenticated and user.is_admin:
-        return True
-    # check page read permission
-    if permission.upper() == "READ":
-        if app.config["READ_ACCESS"].upper() == "ANONYMOUS":
-            return True
-        if (
-            app.config["READ_ACCESS"].upper() == "REGISTERED"
-            and user.is_authenticated
-        ):
-            return True
-        if (
-            app.config["READ_ACCESS"].upper() == "APPROVED"
-            and user.is_authenticated
-            and user.is_approved
-        ):
-            return True
-        if (
-            user.is_authenticated
-            and user.is_approved
-            and user.allow_read
-        ):
-            return True
-        # admins have permissions for everything
-        if (
-            user.is_authenticated
-            and user.is_admin
-        ):
-            return True
-    # check page edit permission
-    if permission.upper() == "WRITE":
-        # if you are not allowed to read, you are not allowed to write
-        if not has_permission("READ"):
-            return False
-        if app.config["WRITE_ACCESS"].upper() == "ANONYMOUS":
-            return True
-        if (
-            app.config["WRITE_ACCESS"].upper() == "REGISTERED"
-            and user.is_authenticated
-        ):
-            return True
-        if (
-            app.config["WRITE_ACCESS"].upper() == "APPROVED"
-            and user.is_authenticated
-            and user.is_approved
-        ):
-            return True
-        if (
-            user.is_authenticated
-            and user.is_approved
-            and user.allow_write
-        ):
-            return True
-        # admins have permissions for everything
-        if (
-            user.is_authenticated
-            and user.is_admin
-        ):
-            return True
-    # check upload permission
-    if permission.upper() == "UPLOAD":
-        if not has_permission("WRITE"):
-            return False
-        if app.config["ATTACHMENT_ACCESS"] == "ANONYMOUS":
-            return True
-        if (
-            app.config["ATTACHMENT_ACCESS"] == "REGISTERED"
-            and user.is_authenticated
-        ):
-            return True
-        if (
-            app.config["ATTACHMENT_ACCESS"] == "APPROVED"
-            and user.is_authenticated
-            and user.is_approved
-        ):
-            return True
-        if (
-            user.is_authenticated
-            and user.is_approved
-            and user.allow_upload
-        ):
-            return True
-        # admins have permissions for everything
-        if (
-            user.is_authenticated
-            and user.is_admin
-        ):
-            return True
-    if permission.upper() == "ADMIN":
-        if user.is_anonymous:
-            return False
-        return True == user.is_admin
-
-    return False
+    return auth_manager.has_permission(permission, user)
 
 
 app.jinja_env.globals.update(has_permission=has_permission)
+
+# these features help enable / disable the relevant parts of the UI
+app.jinja_env.globals.update(
+    auth_supported_features=auth_manager.supported_features()
+)
 
 # vim: set et ts=8 sts=4 sw=4 ai:

--- a/otterwiki/templates/admin.html
+++ b/otterwiki/templates/admin.html
@@ -25,9 +25,11 @@
 {% for user in user_list %}
       <tr>
         <td>
+            {% if auth_supported_features['editing'] %}
             <a href="{{ url_for("user", uid=user.id) }}">
                 <i class="fas fa-user-edit"></i>
             </a>
+            {% endif %}
         </td>
         <td>
             {{user.email}}
@@ -37,31 +39,36 @@
         </td>
         <td>
           <div class="custom-checkbox">
-              <input type="checkbox" id="checkbox-a-{{user.id}}" name="is_approved" value="{{user.id}}" {{"checked=\"checked\"" if user.is_approved  }}>
+              <input type="checkbox" id="checkbox-a-{{user.id}}" name="is_approved" value="{{user.id}}" {{"checked=\"checked\"" if
+                user.is_approved }} {% if not auth_supported_features['editing'] %}disabled{% endif %}>
             <label for="checkbox-a-{{user.id}}"></label>
           </div>
         </td>
         <td>
           <div class="custom-checkbox">
-              <input type="checkbox" id="checkbox-b-{{user.id}}" name="allow_read" value="{{user.id}}" {{ "checked=\"checked\"" if user.allow_read }}>
+              <input type="checkbox" id="checkbox-b-{{user.id}}" name="allow_read" value="{{user.id}}" {{ "checked=\" checked\"" if
+                user.allow_read }} {% if not auth_supported_features['editing'] %}disabled{% endif %}>
             <label for="checkbox-b-{{user.id}}"></label>
           </div>
         </td>
         <td>
           <div class="custom-checkbox">
-              <input type="checkbox" id="checkbox-c-{{user.id}}" name="allow_write" value="{{user.id}}" {{ "checked=\"checked\"" if user.allow_write }}>
+              <input type="checkbox" id="checkbox-c-{{user.id}}" name="allow_write" value="{{user.id}}" {{ "checked=\" checked\"" if
+                user.allow_write }} {% if not auth_supported_features['editing'] %}disabled{% endif %}>
             <label for="checkbox-c-{{user.id}}"></label>
           </div>
         </td>
         <td>
           <div class="custom-checkbox">
-              <input type="checkbox" id="checkbox-d-{{user.id}}" name="allow_upload" value="{{user.id}}" {{ "checked=\"checked\"" if user.allow_upload }}>
+              <input type="checkbox" id="checkbox-d-{{user.id}}" name="allow_upload" value="{{user.id}}" {{ "checked=\" checked\"" if
+                user.allow_upload }} {% if not auth_supported_features['editing'] %}disabled{% endif %}>
             <label for="checkbox-d-{{user.id}}"></label>
           </div>
         </td>
         <td>
           <div class="custom-checkbox">
-              <input type="checkbox" id="checkbox-e-{{user.id}}" name="is_admin" value="{{user.id}}" {{ "checked=\"checked\"" if user.is_admin }}>
+              <input type="checkbox" id="checkbox-e-{{user.id}}" name="is_admin" value="{{user.id}}" {{ "checked=\" checked\"" if
+                user.is_admin }} {% if not auth_supported_features['editing'] %}disabled{% endif %}>
             <label for="checkbox-e-{{user.id}}"></label>
           </div>
         </td>
@@ -77,7 +84,8 @@
       </em>
   </div>
   <div class="mt-10">
-    <input class="btn btn-primary" name="update_permissions" type="submit" value="Update Privileges">
+    <input class="btn btn-primary" name="update_permissions" type="submit" value="Update Privileges" {% if not
+      auth_supported_features['editing'] %}disabled{% endif %}>
   </div>
 </form>
 </div>

--- a/otterwiki/templates/layout.html
+++ b/otterwiki/templates/layout.html
@@ -136,12 +136,14 @@
                         </span>
                         Settings
                     </a>
+  {% if auth_supported_features['logout'] %}
                     <a href="{{ url_for("logout") }}"  class="dropdown-item-with-icon">
                         <span class="dropdown-icon">
                             <i class="fas fa-sign-out-alt"></i>
                         </span>
                         Logout
                     </a>
+  {% endif %}
 {% endif %}
 {% endblock %}
                   </div> <!-- inner dropdown -->

--- a/otterwiki/templates/settings.html
+++ b/otterwiki/templates/settings.html
@@ -44,17 +44,20 @@
 <form action="{{url_for("settings")}}" method="POST">
   <div class="form-group">
   <label for="name" class="required">First and Lastname</label>
-  <input name="name" type="text" class="form-control" id="name" value="{{current_user.name if current_user.name}}">
+  <input name="name" type="text" class="form-control" id="name" value="{{current_user.name if current_user.name}}" {% if
+    not auth_supported_features['editing'] %}disabled{% endif %}>
     <div class="form-text">
       Please note that changing the Name doesn't not change anything in the edit history.
     </div>
   </div>
-  <input class="btn btn-primary" type="submit" value="Update Name">
+  <input class="btn btn-primary" type="submit" value="Update Name" {% if not auth_supported_features['editing']
+    %}disabled{% endif %}>
 </form>
 </div>
 </div>
 {#
 #}
+{% if auth_supported_features['passwords'] %}
 <div class="card">
 <div class="mw-full w-600">
 <h2 class="card-title">Change Password</h2>
@@ -83,6 +86,7 @@
 </form>
 </div>
 </div>
+{% endif %}
 {#
 #}
 {% if config.GIT_WEB_SERVER %}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -21,7 +21,10 @@ def test_settings_update_name(app_with_user, test_client):
     # check name
     rv = test_client.get("/-/settings")
     assert 200 == rv.status_code
-    assert '<input name="name" type="text" class="form-control" id="name" value="Test User">' in rv.data.decode()
+    assert (
+        '<input name="name" type="text" class="form-control" id="name" value="Test User"'
+        in rv.data.decode()
+    )
 
     # update name
     rv = test_client.post(
@@ -31,7 +34,10 @@ def test_settings_update_name(app_with_user, test_client):
         },
         follow_redirects=True,
     )
-    assert '<input name="name" type="text" class="form-control" id="name" value="Updated Name">' in rv.data.decode()
+    assert (
+        '<input name="name" type="text" class="form-control" id="name" value="Updated Name"'
+        in rv.data.decode()
+    )
     assert 'Your name was updated successfully' in rv.data.decode()
     # restore name
     rv = test_client.post(
@@ -42,7 +48,10 @@ def test_settings_update_name(app_with_user, test_client):
         follow_redirects=True,
     )
     assert 200 == rv.status_code
-    assert '<input name="name" type="text" class="form-control" id="name" value="Test User">' in rv.data.decode()
+    assert (
+        '<input name="name" type="text" class="form-control" id="name" value="Test User"'
+        in rv.data.decode()
+    )
 
 
 def test_settings_update_name_failed(app_with_user, test_client):
@@ -59,7 +68,10 @@ def test_settings_update_name_failed(app_with_user, test_client):
     # check name
     rv = test_client.get("/-/settings")
     assert 200 == rv.status_code
-    assert '<input name="name" type="text" class="form-control" id="name" value="Test User">' in rv.data.decode()
+    assert (
+        '<input name="name" type="text" class="form-control" id="name" value="Test User"'
+        in rv.data.decode()
+    )
 
     # update name
     rv = test_client.post(
@@ -69,7 +81,10 @@ def test_settings_update_name_failed(app_with_user, test_client):
         },
         follow_redirects=True,
     )
-    assert '<input name="name" type="text" class="form-control" id="name" value="Test User">' in rv.data.decode()
+    assert (
+        '<input name="name" type="text" class="form-control" id="name" value="Test User"'
+        in rv.data.decode()
+    )
     assert 'Your name must be at least one character.' in rv.data.decode()
 
 


### PR DESCRIPTION
- This commit adds a new auth manager class for authorizing via proxy headers `ProxyHeaderAuth` which can be selected by setting the `AUTH_METHOD` env var to `PROXY_HEADER`

    - This auth manager looks for the following headers in order to
      create a "pseudo-user" on each request. No users are committed to
      the SQLite database when using this auth manager.

        - `X-OtterWiki-Name` - the name of the user to include on the Git commit when editing a page
        - `X-OtterWiki-Email` - the email of the user to include on the Git commit when editing a page
        - `X-OtterWiki-Permissions` - a comma separated list of permissions to grant to the user

    - The Docker `entrypoint.sh` script has been updated to pass the `AUTH_METHOD` config option thru if set in the environment.

- `has_permission(permission, user)` is now a method specific to each auth manager

- auth managers now implement a `supported_features()` method to detail which features they support (like whether an auth manager allows a user to change their name or password, or logout)

    - the features object this method returns is present in all Jinja
      templates as the variable `auth_supported_features`

    - the settings page was updated to prevent a user from editing their
      password and name if it is not supported by the current auth
      manager.

    - the dropdown menu present on all page was updated to hide the
      "logout" button if it is not supported by the current auth manager

- The `test_settings.py` test was updated to tolerate extra whitespace

CC @redimp. I didn't make the headers configurable for now, and I'm sure this is a bit hacky, so interested to hear what you think.