### PR TITLE
Plugin example: move wikilink processing

### DIFF
--- a/otterwiki/otterwiki_plugins.py
+++ b/otterwiki/otterwiki_plugins.py
@@ -1,0 +1,79 @@
+# This file contains both the "plugin spec" for OtterWiki, and several
+# plugins included with the app itself.
+
+import pluggy
+import re
+import urllib
+
+hookspec = pluggy.HookspecMarker("otterwiki")
+hookimpl = pluggy.HookimplMarker("otterwiki")
+
+
+class OtterWikiPluginSpec:
+    """A hook specification namespace for OtterWiki."""
+
+    @hookspec
+    def preprocess_markdown(self, md):
+        """
+        This hook receives a markdown string, and can transform it any way it
+        sees fit. It is called before the markdown is rendered into HTML.
+        """
+
+
+class WikiLinkPlugin:
+    """This plugin preprocesses links in the [[WikiLink]] style."""
+
+    wiki_link_outer = re.compile(
+        r'\[\['
+        r'([^\]]+)'
+        r'\]\](?!\])'  # [[  # ...  # ]]
+    )
+    wiki_link_inner = re.compile(r'([^\|]+)\|?(.*)')
+
+    @hookimpl
+    def preprocess_markdown(self, md):
+        """
+        Will turn
+            [[Page]]
+            [[Title|Link]]
+        into
+            [Page](/Page)
+            [Title](/Link)
+        """
+        for m in self.wiki_link_outer.finditer(md):
+            title, link = self.wiki_link_inner.findall(m.group(1))[0]
+            if link == '':
+                link = title
+            if not link.startswith("/"):
+                link = f"/{link}"
+            # quote link (and just in case someone encoded already: unquote)
+            link = urllib.parse.quote(urllib.parse.unquote(link), safe="/#")
+            md = md.replace(m.group(0), f'[{title}]({link})')
+
+        return md
+
+
+# pluggy doesn't by default handle chaining the output of one plugin into
+# another, so this is a small utility function to do this. it likely does not
+# support hook wrappers correctly.
+def chain_hooks_single_arg(hook_name, **kwargs):
+    if len(kwargs.keys()) > 1:
+        raise "chain_hooks_single_arg is designed to handle a single argument."
+
+    [(arg_name, arg)] = list(kwargs.items())
+    impls = getattr(plugin_manager.hook, hook_name).get_hookimpls()
+
+    result = arg
+    for impl in impls:
+        fn = getattr(impl, 'function')
+        result = fn(**{arg_name: result})
+
+    return result
+
+
+# this plugin_manager is exported so the normal pluggy API can be used in
+# addition to the utility function above.
+plugin_manager = pluggy.PluginManager("otterwiki")
+plugin_manager.add_hookspecs(OtterWikiPluginSpec)
+plugin_manager.register(WikiLinkPlugin())
+plugin_manager.load_setuptools_entrypoints("otterwiki")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "unidiff==0.7.5",
     "flask-htmlmin==2.2.1",
     "beautifulsoup4==4.12.3",
+    "pluggy==1.4.0",
 ]
 
 [project.urls]

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -2,7 +2,8 @@
 # vim: set et ts=8 sts=4 sw=4 ai:
 
 import pytest
-from otterwiki.renderer import render, preprocess_wiki_links, clean_html
+from otterwiki.otterwiki_plugins import WikiLinkPlugin
+from otterwiki.renderer import render, clean_html
 
 
 def test_lastword():
@@ -127,25 +128,30 @@ def test_wiki_link_in_table(req_ctx):
 
 
 def test_preprocess_wiki_links():
-    md = preprocess_wiki_links(
+    plugin = WikiLinkPlugin()
+    md = plugin.preprocess_markdown(
         """
-        [[Page]]
-        [[Title|Link]]
-        [[Text with space|Link with space]]
-        """
+         [[Page]]
+         [[Title|Link]]
+         [[Text with space|Link with space]]
+         """
     )
     assert '[Page](/Page)' in md
     assert '[Title](/Link)' in md
-    assert '[Page](/Page)' == preprocess_wiki_links("[[Page]]")
-    assert '[Title](/Link)' == preprocess_wiki_links("[[Title|Link]]")
-    assert '[Text with space](/Link%20with%20space)' == preprocess_wiki_links(
-        "[[Text with space|Link with space]]"
+    assert '[Page](/Page)' == plugin.preprocess_markdown("[[Page]]")
+    assert '[Title](/Link)' == plugin.preprocess_markdown("[[Title|Link]]")
+    assert (
+        '[Text with space](/Link%20with%20space)'
+        == plugin.preprocess_markdown("[[Text with space|Link with space]]")
     )
-    assert '[Text with space](/Link%20with%20space)' == preprocess_wiki_links(
-        "[[Text with space|Link%20with%20space]]"
+    assert (
+        '[Text with space](/Link%20with%20space)'
+        == plugin.preprocess_markdown(
+            "[[Text with space|Link%20with%20space]]"
+        )
     )
     # make sure fragment identifier of the URL survived the parser
-    assert '[Random#Title](/Random#Title)' == preprocess_wiki_links(
+    assert '[Random#Title](/Random#Title)' == plugin.preprocess_markdown(
         "[[Random#Title]]"
     )
 


### PR DESCRIPTION
- This PR uses the `pluggy` framework mentioned in #91 to move the "wikilink" parsing functionality to a separate "plugin" that is still housed within the OtterWiki codebase.

- The wikilink parsing code is unchanged, and was just moved to a WikiLinkPlugin class, which implements the new `preprocess_markdown` hook.

- The WikiLinkPlugin is manually registered, but this commit also includes code to automatically discover plugins installed as Python packages if they use the "otterwiki" Setuptools entrypoint. This has yet to be tested, but should work.

- Tests have been updated.

CC @redimp - what do you think? This should be a really easy/simple hook to start with.