### PR TITLE
Allow disabling of registration

### DIFF
--- a/otterwiki/preferences.py
+++ b/otterwiki/preferences.py
@@ -79,6 +79,7 @@ def handle_app_preferences(form):
     for name in ["READ_access", "WRITE_access", "ATTACHMENT_access"]:
         _update_preference(name.upper(),form.get(name, "ANONYMOUS"))
     for checkbox in [
+        "disable_registration",
         "auto_approval",
         "email_needs_confirmation",
         "notify_admins_on_register",

--- a/otterwiki/server.py
+++ b/otterwiki/server.py
@@ -26,6 +26,7 @@ app.config.update(
     WRITE_ACCESS="ANONYMOUS",
     ATTACHMENT_ACCESS="ANONYMOUS",
     AUTO_APPROVAL=True,
+    DISABLE_REGISTRATION=False,
     EMAIL_NEEDS_CONFIRMATION=True,
     NOTIFY_ADMINS_ON_REGISTER=False,
     NOTIFY_USER_ON_APPROVAL=False,
@@ -106,6 +107,7 @@ def update_app_config():
             if item.name.upper() in [
                 "MAIL_USE_TLS",
                 "MAIL_USE_SSL",
+                "DISABLE_REGISTRATION",
                 "AUTO_APPROVAL",
                 "EMAIL_NEEDS_CONFIRMATION",
                 "NOTIFY_ADMINS_ON_REGISTER",

--- a/otterwiki/templates/admin.html
+++ b/otterwiki/templates/admin.html
@@ -164,6 +164,13 @@ selected="selected"
 {##}
   <div class="form-group">
     <div class="custom-checkbox">
+      <input {%if config.DISABLE_REGISTRATION %}checked{% endif %} type="checkbox" id="disable_registration" name="disable_registration" value="True">
+      <label for="disable_registration">Disable registration</label>
+    </div>
+  </div>
+  {##}
+  <div class="form-group">
+    <div class="custom-checkbox">
       <input {%if config.EMAIL_NEEDS_CONFIRMATION %}checked{% endif %} type="checkbox" id="email_confirmation" name="email_needs_confirmation" value="True">
       <label for="email_confirmation">Registration requires email confirmation</label>
     </div>

--- a/otterwiki/templates/login.html
+++ b/otterwiki/templates/login.html
@@ -20,7 +20,11 @@
     </div>
   </div>
   <input class="btn btn-primary" type="submit" value="Login">
+
+  {% if not config.DISABLE_REGISTRATION %}
   <a href="{{ url_for("register") }}" class="btn btn-link" role="button">Register</a>
+  {% endif %}
+
   <a href="{{ url_for("lost_password") }}" class="btn btn-link" role="button">Lost your password?</a>
 </form>
 {% endblock %}

--- a/otterwiki/templates/lost_password.html
+++ b/otterwiki/templates/lost_password.html
@@ -13,6 +13,8 @@
   </div>
   <input class="btn btn-primary" type="submit" value="Submit">
   <a href="{{ url_for("login") }}" class="btn btn-link" role="button">Login</a>
+  {% if not config.DISABLE_REGISTRATION %}
   <a href="{{ url_for("register") }}" class="btn btn-link" role="button">Register</a>
+  {% endif %}
 </form>
 {% endblock %}

--- a/otterwiki/views.py
+++ b/otterwiki/views.py
@@ -191,6 +191,10 @@ def login():
 
 @app.route("/-/register", methods=["POST", "GET"])
 def register():
+    if app.config['DISABLE_REGISTRATION']:
+        toast("Registration is disabled.", "error")
+        return redirect(url_for("index"))
+
     if request.method == "GET":
         return otterwiki.auth.register_form()
     else:


### PR DESCRIPTION
Adds an option to disable registration.

When enabled, this will hide the link to register on the login and lost password page. Manual GET and POST requests to `/register` will redirect to `index` with an error message in a toast. 

I'm not familiar with Flask, so I don't know if there is a more idiomatic way of handling an invalid POST-request.

It does not touch the link in `initial_home.md`, but registration is enabled by default, so this shouldn't matter.