### PR TITLE
Podman and SELinux fixes to the Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY pyproject.toml MANIFEST.in README.md LICENSE /src/
 WORKDIR /src
 
 # install requirements
-RUN --mount=type=cache,target=/root/.cache \
+RUN --mount=type=cache,target=/root/.cache,Z \
     python -c 'import toml; print("\n".join(toml.load("./pyproject.toml")["project"]["dependencies"]));' > requirements.txt && \
     pip install -r requirements.txt
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@
 # to get started.
 #
 version: '3'
+volumes:
+  otterwiki:
 services:
   web:
     build: .
@@ -17,4 +19,4 @@ services:
     volumes:
       # mount the local directory ./app-data into the container
       # (so settings, database and repository are accessible)
-      - ./app-data:/app-data
+      - otterwiki:/app-data:rw,z


### PR DESCRIPTION
The current Docker / Docker Compose setup does not work on Podman due to volume mount issues. It also does not work if SELinux is in *enforcing* mode, because volume mounts are not correctly labeled.

After applying these changes the setup will work with rootless Podman and SELinux. The changes have been tested on Rocky Linux 9. 