### PR TITLE
Page tree colors

### DIFF
--- a/otterwiki/templates/pageindex.html
+++ b/otterwiki/templates/pageindex.html
@@ -17,12 +17,16 @@
 <div class="pageindex-letterblock"><h2 class="content-title font-weight-bolder pageindex-header">{{letter}}</h2>
 {% for depth, title, url, page_toc in pagelist %}
 <div class="pageindex-pageblock" style="padding-left:{{1.5 * depth}}rem;">
-<a href="{{ url }}" class="global-toc-link font-weight-semi-bold">{{title}}</a>
+{% if '/' in title %}
+<a href="{{ url }}" class="text-success global-toc-link font-weight-semi-bold">{{ title }}</a>
+{% else %}
+<a href="{{ url }}" class="text-primary global-toc-link font-weight-semi-bold">{{ title }}</a>
+{% endif %}
 {% if page_toc %}
 <div class="pagetoc" style="display: none;">
 {% for tocdepth, title, url in page_toc %}
 <div style="word-break: all; padding-left:{{1 * tocdepth}}rem;">
-<a href="{{ url }}" class="global-toc-link">{{title}}</a><br/>
+<a href="{{ url }}" class="text-danger global-toc-link">{{title}}</a><br/>
 </div>
 {% endfor %}
 </div>


### PR DESCRIPTION
Page tree colors, when having many pages in a category and subcategories with its pages, it takes a while to find what you look for. Having categories and subcategories in green text and pages in blue, headlines in red is much more pleasant to find what you look for.

I used the color utilities from Halfmoon

Categories: .text-success
Pages: .text-primary
Headers: .text-danger

example image

![image](https://github.com/user-attachments/assets/ecae242c-72e1-44b7-a2d1-06b680f908cd)

![image](https://github.com/user-attachments/assets/7f11ae12-6a7e-4e31-aca4-e8b3d0e0e3fd)
