### PR TITLE
Draft: add production docker-compose setup

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,40 @@
+---
+version: '3'
+volumes:
+  app-data:
+  letsencrypt:
+  static:
+  db:
+services:
+  db:
+    image: postgres:16.4
+    restart: unless-stopped
+    volumes:
+      - db:/var/lib/postgresql/data:rw,z
+    env_file: .env.prod.db
+  nginx:
+    build:
+      context: nginx
+    restart: unless-stopped
+    env_file:
+      - .env.prod.nginx
+    volumes:
+      - letsencrypt:/etc/letsencrypt:ro,z
+      - static:/app/otterwiki/static:ro,z
+    ports:
+      - "8443:443"
+  web:
+    build:
+      dockerfile: docker/Dockerfile.slim
+    env_file:
+      - .env
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - app-data:/app-data:rw,z
+      - letsencrypt:/etc/letsencrypt:ro,z
+      - static:/app/otterwiki/static:rw,z
+    depends_on:
+      db:
+        condition: service_started

--- a/docker/uwsgi.prod.ini
+++ b/docker/uwsgi.prod.ini
@@ -1,0 +1,35 @@
+[uwsgi]
+module = otterwiki.server
+callable = app
+venv = /opt/venv
+pidfile = /tmp/uwsgi.pid
+plugins = /usr/lib/uwsgi/python
+chdir = /app
+# Graceful shutdown on SIGTERM, see https://github.com/unbit/uwsgi/issues/849#issuecomment-118869386
+hook-master-start = unix_signal:15 gracefully_kill_them_all
+need-app = true
+die-on-term = true
+# we run a single app
+single-interpreter = true
+# For debugging and testing
+show-config = false
+vacuum = false
+# fixing WARNING: you are running uWSGI without its master process manager
+master = true
+# wsgi.file_wrapper is an optimization of the WSGI standard. In some
+# corner case it can raise an error. For example when returning an
+# in-memory bytes buffer (io.Bytesio) in Python 3.5.
+# see https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html
+wsgi-disable-file-wrapper = true
+# enable threads, which are disabled by default
+# see https://uwsgi-docs.readthedocs.io/en/latest/WSGIquickstart.html#a-note-on-python-threads
+enable-threads = true
+# disable logs
+disable-logging = true
+# close the uwsgi processes quicker, when hitting Ctrl-C
+reload-mercy = 5
+worker-reload-mercy = 5
+env = HOME=/app-data
+static-map = /static=/app/otterwiki/static/
+socket = :9090
+listen = 1024

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:1.25.3
+RUN apt-get update && apt-get -y install procps net-tools curl telnet netcat-openbsd less vim
+RUN rm -f /etc/nginx/conf.d/default.conf
+COPY default-ssl.conf /etc/nginx/templates/default-ssl.conf.template

--- a/nginx/certbot-renew.sh
+++ b/nginx/certbot-renew.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+set -e
+
+. ../.env.prod.nginx
+
+CWD=$(pwd)
+
+cd $OTTERWIKI_CONTEXT
+
+# This requires that port redirection is done on the host from port 80 to port 8080
+podman run -it --rm --name certbot -p 8080:80 -v "${OTTERWIKI_VOLUME}:/etc/letsencrypt:rw,Z" certbot/certbot:latest certonly --standalone --non-interactive --agree-tos --email $OTTERWIKI_CERTBOT_EMAIL -d $OTTERWIKI_DOMAIN
+
+podman-compose restart nginx 2>/dev/null || echo "nginx container not running, not restarting it"
+
+cd $CWD

--- a/nginx/default-ssl.conf
+++ b/nginx/default-ssl.conf
@@ -1,0 +1,25 @@
+server {
+    listen       443 ssl;
+    server_name  ${OTTERWIKI_DOMAIN};
+
+    ssl_certificate     /etc/letsencrypt/live/${OTTERWIKI_DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${OTTERWIKI_DOMAIN}/privkey.pem;
+    client_max_body_size 0;
+
+    location / {
+        try_files $uri @app;
+    }
+
+    location @app {
+        uwsgi_pass web:9090;
+        include /etc/nginx/uwsgi_params;
+        uwsgi_param Host $host;
+        uwsgi_param X-Real-IP $remote_addr;
+        uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
+        uwsgi_param X-Forwarded-Proto $http_x_forwarded_proto;
+    }
+
+    location /static {
+        alias /app/otterwiki/static;
+    }
+}


### PR DESCRIPTION
This a draft or "proof of concept" for a "production" Otterwiki than can be run with Docker Compose or Podman Compose. This is meant to be a basis for discussion and not a finished product.

This Otterwiki setup does not make use of supervisord. It reuses the work done in Dockerfile-slim with a minor change (http-socket -> socket) required by the nginx reverse proxy. The setup is composed of three containers:

* *web:* uwsgi process that serves otterwiki
* *nginx:* reverse proxy for uwsgi
* *db:* runs the postgresql database for otterwiki

These containers are configured with environment files:
* .env.prod.web
* .env.prod.nginx
* .env.prod.db

There are four volumes:
* *db*: used by the *db* container
* *app-data*: configuration files for the *web* (otterwiki/uwsgi) container
* *static*: shared static data for *web* (rw) and *nginx* (ro) containers
* *letsencrypt*: certificates used by *nginx* (ro) container

The assumption is that nginx will use Letsencrypt certificates. Creating an renewing those certificates is done outside of the Compose setup. A certbot renewal script for Podman is provided [nginx/certbot-renew.sh](nginx/certbot-renew.sh).

Despite the naming the certificate setup is not tied with Letsencrypt. Renaming the volume and the paths would make it the SSL certificate setup more generic and less confusing when Letsencrypt is not used. 

This code has only been tested with Podman on Rocky Linux 9. Theoretically it should work equally well on Docker, except for the certbot-renew.sh script which would require a few minor changes.