### PR TITLE
Sort sidebar caseless

### DIFF
--- a/otterwiki/sidebar.py
+++ b/otterwiki/sidebar.py
@@ -107,9 +107,9 @@ class SidebarPageIndex:
         # convert OrderedDict into list
         entries = list(tree.items())
         # decide sort_key lambda on mode
-        sort_key = None
+        sort_key = lambda k: (True, str.lower(k[0]))
         if self.mode in ["DIRECTORIES_GROUPED"]:
-            sort_key = lambda k: (len(k[1]["children"]) == 0, k[0])
+            sort_key = lambda k: (len(k[1]["children"]) == 0, str.lower(k[0]))
         # sort entries
         filtered_list = sorted(entries, key=sort_key)
         # filter entries


### PR DESCRIPTION
Make sort_key use lowercase for sorting.

With RETAIN_PAGE_NAME_CASE = True, page and directory names can be mixes of uppercase and lowercase. This commit changes the sorting behavior to treat everything lowercase for sorting. This gives aAabBbcCc... instead of ABCaabbcc...