### PR TITLE
Extend menu buttons with (some) missing functionality (alerts, panels, quote, spoiler, expand etc.)

### DIFF
--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -112,7 +112,7 @@ var otterwiki_editor = {
         }
 
         cm_editor.focus();
-    }, // TODO: consider renaming toggleBlock to toggleSelection?
+    },
     _toggleMultilineBlock: function(syntax_start_chars, header_regex=null, syntax_end_chars=null) {
         // This function prepends and appends a selection of one or more entire lines
         // with a new line of "syntax_(start|end)_chars".

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -195,6 +195,26 @@ var otterwiki_editor = {
     strikethrough: function() {
         otterwiki_editor._toggleBlock("~~", "strikethrough");
     },
+    spoiler: function() {
+        otterwiki_editor._toggleLines(">! ", [/\s*>!\s+/], "spoiler");
+    },
+    expand: function() {
+        // FIXME: This does seem a little hacky - it works, though...
+        // add the header line first
+        const first_line = otterwiki_editor._getSelectedLines()[0];
+        const line = cm_editor.getLine(first_line);
+
+        // drop the header prefix but leave any expand syntax in-place for now
+        let updated_line = line.replace(/(\s*>\|\s+)?#\s+/, "$1")
+        // if the re didn't alter the line, add the prefix
+        if (updated_line == line) {
+            updated_line = "# " + line;
+        }
+        otterwiki_editor._setLine(first_line, updated_line);
+
+        // then add the expand syntax
+        otterwiki_editor._toggleLines(">| ", [/\s*>\|\s+/], "expand");
+    },
     code: function() {
         otterwiki_editor._toggleBlock(["`","```"], "code");
     },
@@ -798,4 +818,3 @@ document.querySelector('#content-wrapper').addEventListener('scroll', (event) =>
     }
   }
 });
-

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -423,6 +423,9 @@ var otterwiki_editor = {
 
         cm_editor.focus();
     },
+    diagram: function() {
+        otterwiki_editor._toggleMultilineBlock("```mermaid", /^```mermaid/, "```");
+    },
     alertNote: function() {
         otterwiki_editor._toggleAlert("note");
     },
@@ -450,6 +453,9 @@ var otterwiki_editor = {
         cm_editor.replaceSelection(text + link);
 
         cm_editor.focus();
+    },
+    footnote: function() {
+        // TODO: Insert [^selectedword] AND [^selectedword]: description
     },
     _findNextOccurenceLine: function(lineContent) {
         // Find the next line starting AFTER the current selection that matches lineContent

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -1,6 +1,7 @@
 /* vim: set et sts=4 ts=4 sw=4 ai: */
 
 const lineEnd = 999999;
+const maxMultiLevels = 5;
 
 var otterwiki_editor = {
     /* simple functions */
@@ -161,7 +162,7 @@ var otterwiki_editor = {
         }
         cm_editor.focus();
     },
-    _toggleLinesMultiLevel: function(indentChar, maxLevel=5) {
+    _toggleLinesMultiLevel: function(indentChar, maxLevel=maxMultiLevels) {
         if (!cm_editor) { return; }
         for (const i of otterwiki_editor._getSelectedLines())
         {
@@ -227,8 +228,7 @@ var otterwiki_editor = {
         }
 
         // Finally, simply quote all selected lines (the header part is what makes alerts special)
-        // TODO: once we allow multilevel quotes, we need to consider this here and set a max-quote-level
-        otterwiki_editor.quote();
+        otterwiki_editor.quote(multilevel=false);
     },
     _getState: function(pos) {
         var cm = cm_editor;
@@ -311,8 +311,8 @@ var otterwiki_editor = {
         otterwiki_editor._toggleBlock(["`","```"], "code");
     },
     // quote: increase the markdown quote level till five, remove afterwards
-    quote: function () {
-        otterwiki_editor._toggleLinesMultiLevel(indentChar=">");
+    quote: function (multilevel=true) {
+        otterwiki_editor._toggleLinesMultiLevel(indentChar=">", maxLevel=multilevel ? maxMultiLevels : 1);
     },
     ul: function() {
         otterwiki_editor._toggleLines("- ",[/\s*[-+*]\s+/], "ul");

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -21,7 +21,7 @@ var otterwiki_editor = {
                 ch: 0
             },
             anchor = {
-                line: lines[lines.length - 1] + 1,
+                line: lines[lines.length - 1],
                 ch: lineEnd
             }
         );
@@ -166,6 +166,7 @@ var otterwiki_editor = {
             otterwiki_editor._setLine(selectedLines[0], headerValue + "\n" + firstLine);
 
             // set the selection so the newly added extra line is being included as well
+            selectedLines.push(selectedLines[selectedLines.length - 1] + 1);
             otterwiki_editor._setSelectedLines(selectedLines);
 
             selectedLines = otterwiki_editor._getSelectedLines();
@@ -218,6 +219,9 @@ var otterwiki_editor = {
             let prefix = "";
             if (!lastLine.trim().match(/^$/)) { // last selected line is not empty
                 prefix = lastLine + "\n";
+
+                // as we are adding a newline, we need to extend the selected lines by 1
+                selectedLines.push(selectedLines[selectedLines.length - 1] + 1);
             }
             otterwiki_editor._setLine(lastLineNum, prefix + tailValue);
 
@@ -301,6 +305,7 @@ var otterwiki_editor = {
             otterwiki_editor._setLine(selectedLines[0], headerValue + "\n" + firstLine);
 
             // set the selection so the newly added extra line is being included as well
+            selectedLines.push(selectedLines[selectedLines.length - 1] + 1);
             otterwiki_editor._setSelectedLines(selectedLines);
 
         } else {

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -104,7 +104,7 @@ var otterwiki_editor = {
                     cm_editor.replaceSelection(text);
                     // update end cursor (start cursor is fine)
                     cursor_end.ch = cursor_end.ch - end_length;
-                    // if on the same line // FIXME: Is this actually relevant? this is the same as the line above
+                    // if on the same line
                     if (cursor_start.line == cursor_end.line) { cursor_end.ch = cursor_end.ch - end_length; }
                     // select new area
                     cm_editor.setSelection(cursor_start, cursor_end);
@@ -116,7 +116,7 @@ var otterwiki_editor = {
                 cm_editor.replaceSelection(text);
                 // update end cursor (start cursor is fine)
                 cursor_end.ch = cursor_end.ch + end_char.length;
-                // if on the same line // FIXME: Is this actually relevant? this is the same as the line above
+                // if on the same line
                 if (cursor_start.line == cursor_end.line) { cursor_end.ch = cursor_end.ch + end_char.length; }
                 // select new area
                 cm_editor.setSelection(cursor_start, cursor_end);
@@ -295,7 +295,6 @@ var otterwiki_editor = {
     },
     _toggleAlert: function(header) {
 
-        // TODO: add functionality to "unalert" the selection
         const headerValue = "[!" + header.toUpperCase() + "]";
         const headerRegex = "^> \\[!(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\]\\s*$";
         let selectedLines = otterwiki_editor._getSelectedLines();

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -291,20 +291,22 @@ var otterwiki_editor = {
         otterwiki_editor._toggleLines(">! ", [/\s*>!\s+/], "spoiler");
     },
     expand: function() {
-        // FIXME: This does seem a little hacky - it works, though...
-        // add the header line first
+        // Determine the current format of the first selected line
+        // If it already is a header -> undo the expand blcok
+        // otherwise, add a markdown header indicator
         const first_line = otterwiki_editor._getSelectedLines()[0];
         const line = cm_editor.getLine(first_line);
 
-        // drop the header prefix but leave any expand syntax in-place for now
+        // Apply the header regex (matches both, lines with expand and lines without)
         let updated_line = line.replace(/(\s*>\|\s+)?#\s+/, "$1")
-        // if the re didn't alter the line, add the prefix
+        // if the regex did not alter the line, there is no header present yet
+        // --> add the header prefix
         if (updated_line == line) {
             updated_line = "# " + line;
         }
         otterwiki_editor._setLine(first_line, updated_line);
 
-        // then add the expand syntax
+        // Finally, add the expand syntax on each selected line
         otterwiki_editor._toggleLines(">| ", [/\s*>\|\s+/], "expand");
     },
     code: function() {

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -14,6 +14,18 @@ var otterwiki_editor = {
         cm_editor.redo();
     },
     /* helper functions */
+    _setSelection: function(lines) {
+        cm_editor.setSelection(
+            head = {
+                line: lines[0],
+                ch: 0
+            },
+            anchor = {
+                line: lines[lines.length - 1] + 1,
+                ch: lineEnd
+            }
+        );
+    },
     _getSelectedLines: function() {
         const [s, e] = [cm_editor.getCursor('start').line, cm_editor.getCursor('end').line]
         return [...Array(e - s + 1).keys()].map(i => i + s);
@@ -155,16 +167,7 @@ var otterwiki_editor = {
             otterwiki_editor._setLine(selectedLines[0], headerValue + "\n" + firstLine);
 
             // set the selection so the newly added extra line is being included as well
-            cm_editor.setSelection(
-                head={
-                    line: selectedLines[0],
-                    ch: 0
-                },
-                anchor={
-                    line: selectedLines[selectedLines.length - 1] + 1,
-                    ch: lineEnd
-                }
-            );
+            otterwiki_editor._setSelection(selectedLines);
 
             selectedLines = otterwiki_editor._getSelectedLines();
 
@@ -201,17 +204,7 @@ var otterwiki_editor = {
             otterwiki_editor._setLine(lastLineNum, prefix + tailValue);
 
             // update the selection
-            // TODO: This is exactly the same code as for firstLine - consider refactoring?
-            cm_editor.setSelection(
-                head={
-                    line: selectedLines[0],
-                    ch: 0
-                },
-                anchor={
-                    line: selectedLines[selectedLines.length - 1] + 1,
-                    ch: lineEnd
-                }
-            );
+            otterwiki_editor._setSelection(selectedLines);
         }
     },
     _toggleLines: function(line_prefix, line_re, token) {
@@ -288,16 +281,7 @@ var otterwiki_editor = {
             otterwiki_editor._setLine(selectedLines[0], headerValue + "\n" + firstLine);
 
             // set the selection so the newly added extra line is being included as well
-            cm_editor.setSelection(
-                head={
-                    line: selectedLines[0],
-                    ch: 0
-                },
-                anchor={
-                    line: selectedLines[selectedLines.length - 1] + 1,
-                    ch: lineEnd
-                }
-            );
+            otterwiki_editor._setSelection(selectedLines);
 
         } else {
             otterwiki_editor._setLine(selectedLines[0], headerValue);

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -158,6 +158,7 @@ var otterwiki_editor = {
 
             } else { // the first line is a header, but a different one -> replace header and quit
                 otterwiki_editor._setLine(selectedLines[0], headerValue);
+                cm_editor.focus();
                 return;
             }
 
@@ -180,7 +181,7 @@ var otterwiki_editor = {
                 for (const endChar of syntaxEndChars) {
                     if (lineValue.trim() == endChar) {
                         otterwiki_editor._setLine(ln, "");
-                        return;
+                        break;
                     }
                 }
             }
@@ -217,6 +218,8 @@ var otterwiki_editor = {
             // update the selection
             otterwiki_editor._setSelectedLines(selectedLines);
         }
+
+        cm_editor.focus();
     },
     _toggleLines: function(line_prefix, line_re, token) {
         if (!(line_re instanceof Array)) {

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -195,6 +195,8 @@ var otterwiki_editor = {
     strikethrough: function() {
         otterwiki_editor._toggleBlock("~~", "strikethrough");
     },
+    // TODO: How do we handle multiple levels of spoilers, expands etc.?
+    //       Maybe we could hijack the Tab indentation?
     spoiler: function() {
         otterwiki_editor._toggleLines(">! ", [/\s*>!\s+/], "spoiler");
     },
@@ -217,6 +219,9 @@ var otterwiki_editor = {
     },
     code: function() {
         otterwiki_editor._toggleBlock(["`","```"], "code");
+    },
+    quote: function () {
+        otterwiki_editor._toggleLines("> ", [/\s*>\s+/], "quote")
     },
     ul: function() {
         otterwiki_editor._toggleLines("- ",[/\s*[-+*]\s+/], "ul");

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -186,15 +186,28 @@ var otterwiki_editor = {
             }
 
             // We only get here when the ending line was not found in the selection
-            // TODO: Find block end based on the syntax chars, abort if no end found
-            console.log("ERROR: No block end found! Remove manually.")
+            // Find block end based on the syntax chars, abort if no end found
+            let blockEndLine = -1;
+            for (const endChar of syntaxEndChars) {
+                blockEndLine = otterwiki_editor._findNextOccurenceLine(endChar)
+
+                if (blockEndLine !== -1) {
+                    break;
+                }
+            }
+
+            if (blockEndLine !== -1) {
+                otterwiki_editor._setLine(blockEndLine, "");
+            } else {
+                console.log("ERROR: No block end found! Remove manually.")
+            }
 
         } else {
 
             // Determine whether the last line is empty, and we may just set the block end
             // or it already contains text, requiring us to add another line
             const lastLineNum = selectedLines[selectedLines.length - 1]
-            const lastLine = cm_editor.getLine(selectedLines[lastLineNum]);
+            const lastLine = cm_editor.getLine(lastLineNum);
             let prefix = ""
             if (!lastLine.match("^$")) { // last selected line is not empty
                 prefix = lastLine + "\n";
@@ -434,6 +447,19 @@ var otterwiki_editor = {
         cm_editor.replaceSelection(text + link);
 
         cm_editor.focus();
+    },
+    _findNextOccurenceLine: function(lineContent) {
+        // Find the next line starting AFTER the current selection that matches lineContent
+        const selectedLines = otterwiki_editor._getSelectedLines();
+        const lineAfterSelection = selectedLines[selectedLines.length - 1];
+        const editorLastLine = cm_editor.doc.lineCount();
+
+        for (let l = lineAfterSelection; l < editorLastLine; l++) {
+            if (cm_editor.getLine(l) == lineContent) {
+                return l;
+            }
+        }
+        return -1;
     },
     _findBlock: function(selectBlock = false) {
         var block_start = Number.MAX_SAFE_INTEGER;

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -239,12 +239,12 @@ var otterwiki_editor = {
             if (lineHLevel < 0) { lineHLevel = line.length; }
             if (lineHLevel == 0) {
                 otterwiki_editor._setLine(i, indentChar + " " + line);
-            } else if (lineHLevel < maxLevel) {
+            } else if (lineHLevel/indentChar.length < maxLevel) {
                 // add a level
                 otterwiki_editor._setLine(i, indentChar + line);
             } else {
                 // Remove all indentChars (not sure why the RegExp is needed. It won't work without, though)
-                otterwiki_editor._setLine(i, line.replace(new RegExp("^" + indentChar + "+\\s*"), ''));
+                otterwiki_editor._setLine(i, line.replace(new RegExp("^(?:" + indentChar + ")+\\s*"), ''));
             }
         }
         cm_editor.focus();
@@ -343,11 +343,10 @@ var otterwiki_editor = {
     strikethrough: function() {
         otterwiki_editor._toggleBlock("~~", "strikethrough");
     },
-    // TODO: How do we handle multiple levels of spoilers, expands etc.?
-    //       Maybe we could hijack the Tab indentation?
     spoiler: function() {
-        otterwiki_editor._toggleLines(">! ", [/\s*>!\s+/], "spoiler");
+        otterwiki_editor._toggleLinesMultiLevel(">!");
     },
+    // TODO: How do we handle multiple levels of expands?
     expand: function() {
         // Determine the current format of the first selected line
         // If it already is a header -> undo the expand blcok

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -113,24 +113,24 @@ var otterwiki_editor = {
 
         cm_editor.focus();
     },
-    _toggleMultilineBlock: function(syntax_start_chars, header_regex=null, syntax_end_chars=null) {
+    _toggleMultilineBlock: function(syntaxStartChars, headerRegex=null, syntaxEndChars=null) {
         // This function prepends and appends a selection of one or more entire lines
         // with a new line of "syntax_(start|end)_chars".
 
-        if (!(syntax_start_chars instanceof Array)) {
-            syntax_start_chars = [syntax_start_chars];
+        if (!(syntaxStartChars instanceof Array)) {
+            syntaxStartChars = [syntaxStartChars];
         }
-        if (syntax_end_chars !== null && !(syntax_end_chars instanceof Array) ) {
-            syntax_end_chars = [syntax_end_chars];
+        if (syntaxEndChars !== null && !(syntaxEndChars instanceof Array) ) {
+            syntaxEndChars = [syntaxEndChars];
         } else {
-            syntax_end_chars = syntax_start_chars;
+            syntaxEndChars = syntaxStartChars;
         }
 
         let selectedLines = otterwiki_editor._getSelectedLines();
         if (selectedLines.length == 0) return;
 
-        const headerValue = syntax_start_chars[0];
-        const tailValue = syntax_end_chars[0];
+        const headerValue = syntaxStartChars[0];
+        const tailValue = syntaxEndChars[0];
         let removeBlock = false;
 
         // Decide whether to add or remove the block, and whether the first line already
@@ -140,11 +140,11 @@ var otterwiki_editor = {
 
         // The first line already is a header
         // Determine whether we should remove, or change the header
-        if (header_regex !== null && firstLine.match(header_regex)) {
+        if (headerRegex !== null && firstLine.match(headerRegex)) {
 
             // Decide whether the first line is the current header line
             let isHeader = false;
-            for (const startChar of syntax_start_chars) {
+            for (const startChar of syntaxStartChars) {
                 if (firstLine.trim() == startChar) {
                     isHeader = true;
                     break;
@@ -177,7 +177,7 @@ var otterwiki_editor = {
             for (const ln of selectedLines.splice(1)) {
                 const lineValue = cm_editor.getLine(ln);
 
-                for (const endChar of syntax_end_chars) {
+                for (const endChar of syntaxEndChars) {
                     if (lineValue.trim() == endChar) {
                         otterwiki_editor._setLine(ln, "");
                         return;
@@ -352,17 +352,17 @@ var otterwiki_editor = {
         // Determine the current format of the first selected line
         // If it already is a header -> undo the expand blcok
         // otherwise, add a markdown header indicator
-        const first_line = otterwiki_editor._getSelectedLines()[0];
-        const line = cm_editor.getLine(first_line);
+        const firstLine = otterwiki_editor._getSelectedLines()[0];
+        const line = cm_editor.getLine(firstLine);
 
         // Apply the header regex (matches both, lines with expand and lines without)
-        let updated_line = line.replace(/(\s*>\|\s+)?#\s+/, "$1")
+        let updatedLine = line.replace(/(\s*>\|\s+)?#\s+/, "$1")
         // if the regex did not alter the line, there is no header present yet
         // --> add the header prefix
-        if (updated_line == line) {
-            updated_line = "# " + line;
+        if (updatedLine == line) {
+            updatedLine = "# " + line;
         }
-        otterwiki_editor._setLine(first_line, updated_line);
+        otterwiki_editor._setLine(firstLine, updatedLine);
 
         // Finally, add the expand syntax on each selected line
         otterwiki_editor._toggleLines(">| ", [/\s*>\|\s+/], "expand");

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -14,7 +14,7 @@ var otterwiki_editor = {
         cm_editor.redo();
     },
     /* helper functions */
-    _setSelection: function(lines) {
+    _setSelectedLines: function(lines) {
         cm_editor.setSelection(
             head = {
                 line: lines[0],
@@ -165,7 +165,7 @@ var otterwiki_editor = {
             otterwiki_editor._setLine(selectedLines[0], headerValue + "\n" + firstLine);
 
             // set the selection so the newly added extra line is being included as well
-            otterwiki_editor._setSelection(selectedLines);
+            otterwiki_editor._setSelectedLines(selectedLines);
 
             selectedLines = otterwiki_editor._getSelectedLines();
 
@@ -202,7 +202,7 @@ var otterwiki_editor = {
             otterwiki_editor._setLine(lastLineNum, prefix + tailValue);
 
             // update the selection
-            otterwiki_editor._setSelection(selectedLines);
+            otterwiki_editor._setSelectedLines(selectedLines);
         }
     },
     _toggleLines: function(line_prefix, line_re, token) {
@@ -279,7 +279,7 @@ var otterwiki_editor = {
             otterwiki_editor._setLine(selectedLines[0], headerValue + "\n" + firstLine);
 
             // set the selection so the newly added extra line is being included as well
-            otterwiki_editor._setSelection(selectedLines);
+            otterwiki_editor._setSelectedLines(selectedLines);
 
         } else {
             otterwiki_editor._setLine(selectedLines[0], headerValue);

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -269,6 +269,15 @@ var otterwiki_editor = {
     cl: function() {
         otterwiki_editor._toggleLines("- [ ] ",[/\s*[-+*] \[ \]\s+/], "ul");
     },
+    block_notice: function() {
+        otterwiki_editor._toggleBlock(":::info\n", "notice", "\n:::");
+    },
+    block_warning: function() {
+        otterwiki_editor._toggleBlock(":::warning\n", "warning", "\n:::");
+    },
+    block_danger: function() {
+        otterwiki_editor._toggleBlock(":::danger\n", "danger", "\n:::");
+    },
     img: function(img = "![]()") {
         if (!cm_editor) { return; }
         state = otterwiki_editor._getState();

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -386,13 +386,13 @@ var otterwiki_editor = {
     cl: function() {
         otterwiki_editor._toggleLines("- [ ] ",[/\s*[-+*] \[ \]\s+/], "ul");
     },
-    block_notice: function() {
+    panelNotice: function() {
         otterwiki_editor._toggleMultilineBlock(":::info", /^:::(info|warning|danger)/, ":::");
     },
-    block_warning: function() {
+    panelWarning: function() {
         otterwiki_editor._toggleMultilineBlock(":::warning", /^:::(info|warning|danger)/, ":::");
     },
-    block_danger: function() {
+    panelDanger: function() {
         otterwiki_editor._toggleMultilineBlock(":::danger", /^:::(info|warning|danger)/, ":::");
     },
     img: function(img = "![]()") {

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -310,6 +310,7 @@ var otterwiki_editor = {
     code: function() {
         otterwiki_editor._toggleBlock(["`","```"], "code");
     },
+    // quote: increase the markdown quote level till five, remove afterwards
     quote: function () {
         otterwiki_editor._toggleLinesMultiLevel(indentChar=">");
     },

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -408,19 +408,19 @@ var otterwiki_editor = {
 
         cm_editor.focus();
     },
-    alert_note: function() {
+    alertNote: function() {
         otterwiki_editor._toggleAlert("note");
     },
-    alert_tip: function() {
+    alertTip: function() {
         otterwiki_editor._toggleAlert("tip");
     },
-    alert_important: function() {
+    alertImportant: function() {
         otterwiki_editor._toggleAlert("important");
     },
-    alert_warning: function() {
+    alertWarning: function() {
         otterwiki_editor._toggleAlert("warning");
     },
-    alert_caution: function() {
+    alertCaution: function() {
         otterwiki_editor._toggleAlert("caution");
     },
     link: function(text = "description", url = "https://") {

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -138,7 +138,7 @@ var otterwiki_editor = {
             }
         }
     },
-    _toggleLines: function(line_prefix, line_re, token, special_first_line) {
+    _toggleLines: function(line_prefix, line_re, token) {
         if (!(line_re instanceof Array)) {
             line_re = [line_re];
         }

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -455,7 +455,18 @@ var otterwiki_editor = {
         cm_editor.focus();
     },
     footnote: function() {
-        // TODO: Insert [^selectedword] AND [^selectedword]: description
+        if (otterwiki_editor._getSelectedLines().length > 1) {
+            return;
+            // TODO: we really should tell the user that multiple lines are not supported
+        }
+
+        // TODO
+        /*
+        - If nothing is selected, insert [^#] and select the #
+        - If there is a selection, insert [^ before the selection, and ] after the selection
+
+        In all cases, write the same footnote to the end of the editor, directly after other footnotes
+        */
     },
     _findNextOccurenceLine: function(lineContent) {
         // Find the next line starting AFTER the current selection that matches lineContent

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -175,32 +175,38 @@ var otterwiki_editor = {
         }
 
         if (removeBlock) {
+            let endFound = false;
             for (const ln of selectedLines.splice(1)) {
                 const lineValue = cm_editor.getLine(ln);
 
                 for (const endChar of syntaxEndChars) {
                     if (lineValue.trim() == endChar) {
                         otterwiki_editor._setLine(ln, "");
+                        endFound = true;
                         break;
                     }
                 }
+
+                if (endFound) break;
             }
 
-            // We only get here when the ending line was not found in the selection
-            // Find block end based on the syntax chars, abort if no end found
-            let blockEndLine = -1;
-            for (const endChar of syntaxEndChars) {
-                blockEndLine = otterwiki_editor._findNextOccurenceLine(endChar)
+            if (!endFound) {
+                // We only get here when the ending line was not found in the selection
+                // Find block end based on the syntax chars, abort if no end found
+                let blockEndLine = -1;
+                for (const endChar of syntaxEndChars) {
+                    blockEndLine = otterwiki_editor._findNextOccurenceLine(endChar)
+
+                    if (blockEndLine !== -1) {
+                        break;
+                    }
+                }
 
                 if (blockEndLine !== -1) {
-                    break;
+                    otterwiki_editor._setLine(blockEndLine, "");
+                } else {
+                    console.log("ERROR: No block end found! Remove manually.")
                 }
-            }
-
-            if (blockEndLine !== -1) {
-                otterwiki_editor._setLine(blockEndLine, "");
-            } else {
-                console.log("ERROR: No block end found! Remove manually.")
             }
 
         } else {

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -162,7 +162,7 @@ var otterwiki_editor = {
                 return;
             }
 
-        } else if (!firstLine.match("^$")) { // when the first selected line is not empty
+        } else if (!firstLine.trim().match("^$")) { // when the first selected line is not empty
             otterwiki_editor._setLine(selectedLines[0], headerValue + "\n" + firstLine);
 
             // set the selection so the newly added extra line is being included as well
@@ -215,8 +215,8 @@ var otterwiki_editor = {
             // or it already contains text, requiring us to add another line
             const lastLineNum = selectedLines[selectedLines.length - 1]
             const lastLine = cm_editor.getLine(lastLineNum);
-            let prefix = ""
-            if (!lastLine.match("^$")) { // last selected line is not empty
+            let prefix = "";
+            if (!lastLine.trim().match(/^$/)) { // last selected line is not empty
                 prefix = lastLine + "\n";
             }
             otterwiki_editor._setLine(lastLineNum, prefix + tailValue);

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -422,7 +422,7 @@ var otterwiki_editor = {
         // Finally, add the expand syntax on each selected line
         otterwiki_editor._toggleLines(">| ", [/\s*>\|\s+/], "expand");
     },
-    code: function() {
+    code: function() { // TODO: split this into single and multiline
         otterwiki_editor._toggleBlock(["`","```"], "code");
     },
     // quote: increase the markdown quote level till five, remove afterwards

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -142,7 +142,7 @@ var otterwiki_editor = {
         // Determine whether we should remove, or change the header
         if (header_regex !== null && firstLine.match(header_regex)) {
 
-            // Decide whether the first line is a header line
+            // Decide whether the first line is the current header line
             let isHeader = false;
             for (const startChar of syntax_start_chars) {
                 if (firstLine.trim() == startChar) {
@@ -367,8 +367,11 @@ var otterwiki_editor = {
         // Finally, add the expand syntax on each selected line
         otterwiki_editor._toggleLines(">| ", [/\s*>\|\s+/], "expand");
     },
-    code: function() { // TODO: split this into single and multiline
+    code: function() {
         otterwiki_editor._toggleBlock(["`","```"], "code");
+    },
+    codeBlock: function() {
+        otterwiki_editor._toggleMultilineBlock("```", /^```\w*/)
     },
     // quote: increase the markdown quote level till five, remove afterwards
     quote: function (multilevel=true) {

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -117,8 +117,6 @@ var otterwiki_editor = {
         // This function prepends and appends a selection of one or more entire lines
         // with a new line of "syntax_(start|end)_chars".
 
-        // TODO: Can we re-use this for alerts?
-
         if (!(syntax_start_chars instanceof Array)) {
             syntax_start_chars = [syntax_start_chars];
         }

--- a/otterwiki/templates/editor.html
+++ b/otterwiki/templates/editor.html
@@ -130,31 +130,31 @@
   </button>
   <div class="dropdown-menu dropdown-menu-right w-150" aria-labelledby="navbar-dropdown-toggle-alerts">
     {# TODO: The icons are not really optimal here... #}
-    <a onclick="otterwiki_editor.alert_note()" href="#" class="dropdown-item-with-icon">
+    <a onclick="otterwiki_editor.alertNote()" href="#" class="dropdown-item-with-icon">
         <span class="dropdown-icon">
             <i class="fas fa-info-circle"></i>
         </span>
         Note
     </a>
-    <a onclick="otterwiki_editor.alert_tip()" href="#" class="dropdown-item-with-icon">
+    <a onclick="otterwiki_editor.alertTip()" href="#" class="dropdown-item-with-icon">
         <span class="dropdown-icon">
             <i class="fas fa-lightbulb"></i>
         </span>
         Tip
     </a>
-    <a onclick="otterwiki_editor.alert_important()" href="#" class="dropdown-item-with-icon">
+    <a onclick="otterwiki_editor.alertImportant()" href="#" class="dropdown-item-with-icon">
         <span class="dropdown-icon">
             <i class="fas fa-star"></i>
         </span>
         Important
     </a>
-    <a onclick="otterwiki_editor.alert_warning()" href="#" class="dropdown-item-with-icon">
+    <a onclick="otterwiki_editor.alertWarning()" href="#" class="dropdown-item-with-icon">
         <span class="dropdown-icon">
             <i class="fas fa-exclamation-circle"></i>
         </span>
         Warning
     </a>
-    <a onclick="otterwiki_editor.alert_caution()" href="#" class="dropdown-item-with-icon">
+    <a onclick="otterwiki_editor.alertCaution()" href="#" class="dropdown-item-with-icon">
         <span class="dropdown-icon">
             <i class="fas fa-times-circle"></i>
         </span>

--- a/otterwiki/templates/editor.html
+++ b/otterwiki/templates/editor.html
@@ -163,10 +163,45 @@
   </div>
 </div>
 {##}
-<button onclick="otterwiki_editor.link()" class="btn btn-editor btn-xs ml-5 hidden-sm-and-down" title="Link"><i class="fas fa-link"></i></button>
-<!-- TODO: Create "References Menu" and add footnote as option? -->
-<button onclick="otterwiki_editor.img()" class="btn btn-editor btn-xs hidden-sm-and-down" title="Picture"><i class="far fa-image"></i></button>
-<!-- TODO: Create "Graphics Menu" and add diamgram as option? -->
+<div class="dropdown">
+  <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-references" title="References Menu">
+    <i class="fas fa-link"></i>
+  </button>
+  <div class="dropdown-menu dropdown-menu-right w-150" aria-labelledby="navbar-dropdown-toggle-references">
+    <a onclick="otterwiki_editor.link()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-link"></i>
+        </span>
+        Link
+    </a>
+    <a onclick="otterwiki_editor.footnote()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-asterisk"></i>
+        </span>
+        Footnote
+    </a>
+  </div>
+</div>
+{##}
+<div class="dropdown">
+  <button class="btn btn-editor hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-graphics" title="Graphics Menu">
+    <i class="fas fa-images"></i>
+  </button>
+  <div class="dropdown-menu dropdown-menu-right w-150" aria-labelledby="navbar-dropdown-toggle-graphics">
+    <a onclick="otterwiki_editor.img()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-image"></i>
+        </span>
+        Picture
+    </a>
+    <a onclick="otterwiki_editor.diagram()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-project-diagram"></i>
+        </span>
+        Diagram
+    </a>
+  </div>
+</div>
 {##}
 <div class="dropdown">
   <button class="btn btn-editor ml-5 mr-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-table" title="Table Menu">

--- a/otterwiki/templates/editor.html
+++ b/otterwiki/templates/editor.html
@@ -29,47 +29,7 @@
 <button onclick="otterwiki_editor.bold()" class="btn btn-editor btn-xs ml-5 hidden-sm-and-down" title="Bold"><i class="fa fa-bold"></i></button>
 <button onclick="otterwiki_editor.italic()" class="btn btn-editor btn-xs hidden-sm-and-down" title="Italic"><i class="fa fa-italic"></i></button>
 <button onclick="otterwiki_editor.strikethrough()" class="btn btn-editor btn-xs hidden-sm-and-down" title="Strikethrough"><i class="fa fa-strikethrough"></i></button>
-<button onclick="otterwiki_editor.header()" class="btn btn-editor btn-xs ml-5 hidden-sm-and-down" title="Header"><i class="fa fa-heading"></i></button>
-{##}
-<div class="dropdown">
-  <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-spoiler" title="Expandables Menu">
-    <i class="fas fa-eye-slash"></i>
-  </button>
-  <div class="dropdown-menu dropdown-menu-right w-150" aria-labelledby="navbar-dropdown-toggle-spoiler">
-    <a onclick="otterwiki_editor.spoiler()" href="#" class="dropdown-item-with-icon">
-        <span class="dropdown-icon">
-            <i class="fas fa-eye-slash"></i>
-        </span>
-        Spoiler Block
-    </a>
-    <a onclick="otterwiki_editor.expand()" href="#" class="dropdown-item-with-icon">
-        <span class="dropdown-icon">
-            <i class="fas fa-caret-square-down"></i>
-        </span>
-        Folded Block
-    </a>
-  </div>
-</div>
-{##}
-<div class="dropdown">
-  <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-code" title="Code Menu">
-    <i class="fas fa-code"></i>
-  </button>
-  <div class="dropdown-menu dropdown-menu-right w-150" aria-labelledby="navbar-dropdown-toggle-code">
-    <a onclick="otterwiki_editor.code()" href="#" class="dropdown-item-with-icon">
-        <span class="dropdown-icon">
-            <i class="fas fa-code"></i>
-        </span>
-        Inline Code
-    </a>
-    <a onclick="otterwiki_editor.codeBlock()" href="#" class="dropdown-item-with-icon">
-        <span class="dropdown-icon">
-            <i class="fas fa-code"></i>
-        </span>
-        Code Block
-    </a>
-  </div>
-</div>
+<button onclick="otterwiki_editor.header()" class="btn btn-editor btn-xs hidden-sm-and-down" title="Header"><i class="fa fa-heading"></i></button>
 <button onclick="otterwiki_editor.quote()" class="btn btn-editor btn-xs hidden-sm-and-down" title="Block Quote"><i class="fa fa-quote-left"></i></button>
 {##}
 <div class="dropdown">
@@ -94,6 +54,46 @@
             <i class="fas fa-check-square"></i>
         </span>
         Checklist
+    </a>
+  </div>
+</div>
+{##}
+<div class="dropdown">
+  <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-code" title="Code Menu">
+    <i class="fas fa-code"></i>
+  </button>
+  <div class="dropdown-menu dropdown-menu-right w-150" aria-labelledby="navbar-dropdown-toggle-code">
+    <a onclick="otterwiki_editor.code()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-code"></i>
+        </span>
+        Inline Code
+    </a>
+    <a onclick="otterwiki_editor.codeBlock()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-code"></i>
+        </span>
+        Code Block
+    </a>
+  </div>
+</div>
+{##}
+<div class="dropdown">
+  <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-spoiler" title="Expandables Menu">
+    <i class="fas fa-eye-slash"></i>
+  </button>
+  <div class="dropdown-menu dropdown-menu-right w-150" aria-labelledby="navbar-dropdown-toggle-spoiler">
+    <a onclick="otterwiki_editor.spoiler()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-eye-slash"></i>
+        </span>
+        Spoiler Block
+    </a>
+    <a onclick="otterwiki_editor.expand()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-caret-square-down"></i>
+        </span>
+        Folded Block
     </a>
   </div>
 </div>
@@ -125,7 +125,7 @@
 </div>
 {##}
 <div class="dropdown">
-  <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-alerts" title="Alert Menu">
+  <button class="btn btn-editor hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-alerts" title="Alert Menu">
     <i class="fas fa-bell"></i> {# TODO: does this fit? another option would be 'bell-icon'. This is really similar to info-circle, though #}
   </button>
   <div class="dropdown-menu dropdown-menu-right w-150" aria-labelledby="navbar-dropdown-toggle-alerts">
@@ -164,7 +164,9 @@
 </div>
 {##}
 <button onclick="otterwiki_editor.link()" class="btn btn-editor btn-xs ml-5 hidden-sm-and-down" title="Link"><i class="fas fa-link"></i></button>
+<!-- TODO: Create "References Menu" and add footnote as option? -->
 <button onclick="otterwiki_editor.img()" class="btn btn-editor btn-xs hidden-sm-and-down" title="Picture"><i class="far fa-image"></i></button>
+<!-- TODO: Create "Graphics Menu" and add diamgram as option? -->
 {##}
 <div class="dropdown">
   <button class="btn btn-editor ml-5 mr-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-table" title="Table Menu">

--- a/otterwiki/templates/editor.html
+++ b/otterwiki/templates/editor.html
@@ -29,6 +29,7 @@
 <button onclick="otterwiki_editor.bold()" class="btn btn-editor btn-xs ml-5 hidden-sm-and-down" title="Bold"><i class="fa fa-bold"></i></button>
 <button onclick="otterwiki_editor.italic()" class="btn btn-editor btn-xs hidden-sm-and-down" title="Italic"><i class="fa fa-italic"></i></button>
 <button onclick="otterwiki_editor.strikethrough()" class="btn btn-editor btn-xs hidden-sm-and-down" title="Strikethrough"><i class="fa fa-strikethrough"></i></button>
+<button onclick="otterwiki_editor.header()" class="btn btn-editor btn-xs ml-5 hidden-sm-and-down" title="Header"><i class="fa fa-heading"></i></button>
 {##}
 <div class="dropdown">
   <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-spoiler" title="Expandables Menu">
@@ -70,7 +71,6 @@
   </div>
 </div>
 <button onclick="otterwiki_editor.quote()" class="btn btn-editor btn-xs hidden-sm-and-down" title="Block Quote"><i class="fa fa-quote-left"></i></button>
-<button onclick="otterwiki_editor.header()" class="btn btn-editor btn-xs ml-5 hidden-sm-and-down" title="Header"><i class="fa fa-heading"></i></button>
 {##}
 <div class="dropdown">
   <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-list" title="List Menu">
@@ -99,7 +99,7 @@
 </div>
 {##}
 <div class="dropdown">
-  <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-blocks" title="Info Blocks">
+  <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-blocks" title="Panel Menu">
     <i class="fas fa-info-circle"></i> {# TODO: does an 'i' in a circle really fit? #}
   </button>
   <div class="dropdown-menu dropdown-menu-right w-150" aria-labelledby="navbar-dropdown-toggle-blocks">
@@ -107,25 +107,25 @@
         <span class="dropdown-icon">
             <i class="fas fa-info-circle"></i>
         </span>
-        Notice Block
+        Notice Panel
     </a>
     <a onclick="otterwiki_editor.block_warning()" href="#" class="dropdown-item-with-icon">
         <span class="dropdown-icon">
             <i class="fas fa-exclamation-circle"></i>
         </span>
-        Warning Block
+        Warning Panel
     </a>
     <a onclick="otterwiki_editor.block_danger()" href="#" class="dropdown-item-with-icon">
         <span class="dropdown-icon">
             <i class="fas fa-times-circle"></i>
         </span>
-        Danger Block
+        Danger Panel
     </a>
   </div>
 </div>
 {##}
 <div class="dropdown">
-  <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-alerts" title="Alerts">
+  <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-alerts" title="Alert Menu">
     <i class="fas fa-bell"></i> {# TODO: does this fit? another option would be 'bell-icon'. This is really similar to info-circle, though #}
   </button>
   <div class="dropdown-menu dropdown-menu-right w-150" aria-labelledby="navbar-dropdown-toggle-alerts">

--- a/otterwiki/templates/editor.html
+++ b/otterwiki/templates/editor.html
@@ -31,7 +31,7 @@
 <button onclick="otterwiki_editor.strikethrough()" class="btn btn-editor btn-xs hidden-sm-and-down" title="Strikethrough"><i class="fa fa-strikethrough"></i></button>
 {##}
 <div class="dropdown">
-  <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-spoiler" title="Spoiler Menu">
+  <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-spoiler" title="Expandables Menu">
     <i class="fas fa-eye-slash"></i>
   </button>
   <div class="dropdown-menu dropdown-menu-right w-150" aria-labelledby="navbar-dropdown-toggle-spoiler">
@@ -39,13 +39,13 @@
         <span class="dropdown-icon">
             <i class="fas fa-eye-slash"></i>
         </span>
-        Spoiler
+        Spoiler Block
     </a>
     <a onclick="otterwiki_editor.expand()" href="#" class="dropdown-item-with-icon">
         <span class="dropdown-icon">
             <i class="fas fa-caret-square-down"></i>
         </span>
-        Expandable summary
+        Folded Block
     </a>
   </div>
 </div>
@@ -59,13 +59,13 @@
         <span class="dropdown-icon">
             <i class="fas fa-code"></i>
         </span>
-        Code element
+        Inline Code
     </a>
     <a onclick="otterwiki_editor.codeBlock()" href="#" class="dropdown-item-with-icon">
         <span class="dropdown-icon">
             <i class="fas fa-code"></i>
         </span>
-        Code block
+        Code Block
     </a>
   </div>
 </div>

--- a/otterwiki/templates/editor.html
+++ b/otterwiki/templates/editor.html
@@ -29,7 +29,29 @@
 <button onclick="otterwiki_editor.bold()" class="btn btn-editor btn-xs ml-5 hidden-sm-and-down" title="Bold"><i class="fa fa-bold"></i></button>
 <button onclick="otterwiki_editor.italic()" class="btn btn-editor btn-xs hidden-sm-and-down" title="Italic"><i class="fa fa-italic"></i></button>
 <button onclick="otterwiki_editor.strikethrough()" class="btn btn-editor btn-xs hidden-sm-and-down" title="Strikethrough"><i class="fa fa-strikethrough"></i></button>
+{##}
+<div class="dropdown">
+  <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-spoiler" title="Spoiler Menu">
+    <i class="fas fa-eye-slash"></i>
+  </button>
+  <div class="dropdown-menu dropdown-menu-right w-150" aria-labelledby="navbar-dropdown-toggle-spoiler">
+    <a onclick="otterwiki_editor.spoiler()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-eye-slash"></i>
+        </span>
+        Spoiler
+    </a>
+    <a onclick="otterwiki_editor.expand()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-caret-square-down"></i>
+        </span>
+        Expandable summary
+    </a>
+  </div>
+</div>
+{##}
 <button onclick="otterwiki_editor.code()" class="btn btn-editor btn-xs hidden-sm-and-down" title="Code"><i class="fa fa-code"></i></button>
+<button onclick="otterwiki_editor.quote()" class="btn btn-editor btn-xs hidden-sm-and-down" title="Block Quote"><i class="fa fa-quote-left"></i></button>
 <button onclick="otterwiki_editor.header()" class="btn btn-editor btn-xs ml-5 hidden-sm-and-down" title="Header"><i class="fa fa-heading"></i></button>
 {##}
 <div class="dropdown">
@@ -54,6 +76,71 @@
             <i class="fas fa-check-square"></i>
         </span>
         Checklist
+    </a>
+  </div>
+</div>
+{##}
+<div class="dropdown">
+  <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-blocks" title="Info Blocks">
+    <i class="fas fa-info-circle"></i> {# TODO: does an 'i' in a circle really fit? #}
+  </button>
+  <div class="dropdown-menu dropdown-menu-right w-150" aria-labelledby="navbar-dropdown-toggle-blocks">
+    <a onclick="otterwiki_editor.block_notice()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-info-circle"></i>
+        </span>
+        Notice Block
+    </a>
+    <a onclick="otterwiki_editor.block_warning()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-exclamation-circle"></i>
+        </span>
+        Warning Block
+    </a>
+    <a onclick="otterwiki_editor.block_danger()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-times-circle"></i>
+        </span>
+        Danger Block
+    </a>
+  </div>
+</div>
+{##}
+<div class="dropdown">
+  <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-alerts" title="Alerts">
+    <i class="fas fa-bell"></i> {# TODO: does this fit? another option would be 'bell-icon'. This is really similar to info-circle, though #}
+  </button>
+  <div class="dropdown-menu dropdown-menu-right w-150" aria-labelledby="navbar-dropdown-toggle-alerts">
+    {# TODO: The icons are not really optimal here... #}
+    <a onclick="otterwiki_editor.alert_note()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-info-circle"></i>
+        </span>
+        Note
+    </a>
+    <a onclick="otterwiki_editor.alert_tip()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-lightbulb"></i>
+        </span>
+        Tip
+    </a>
+    <a onclick="otterwiki_editor.alert_important()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-star"></i>
+        </span>
+        Important
+    </a>
+    <a onclick="otterwiki_editor.alert_warning()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-exclamation-circle"></i>
+        </span>
+        Warning
+    </a>
+    <a onclick="otterwiki_editor.alert_caution()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-times-circle"></i>
+        </span>
+        Caution
     </a>
   </div>
 </div>

--- a/otterwiki/templates/editor.html
+++ b/otterwiki/templates/editor.html
@@ -103,19 +103,19 @@
     <i class="fas fa-info-circle"></i> {# TODO: does an 'i' in a circle really fit? #}
   </button>
   <div class="dropdown-menu dropdown-menu-right w-150" aria-labelledby="navbar-dropdown-toggle-blocks">
-    <a onclick="otterwiki_editor.block_notice()" href="#" class="dropdown-item-with-icon">
+    <a onclick="otterwiki_editor.panelNotice()" href="#" class="dropdown-item-with-icon">
         <span class="dropdown-icon">
             <i class="fas fa-info-circle"></i>
         </span>
         Notice Panel
     </a>
-    <a onclick="otterwiki_editor.block_warning()" href="#" class="dropdown-item-with-icon">
+    <a onclick="otterwiki_editor.panelWarning()" href="#" class="dropdown-item-with-icon">
         <span class="dropdown-icon">
             <i class="fas fa-exclamation-circle"></i>
         </span>
         Warning Panel
     </a>
-    <a onclick="otterwiki_editor.block_danger()" href="#" class="dropdown-item-with-icon">
+    <a onclick="otterwiki_editor.panelDanger()" href="#" class="dropdown-item-with-icon">
         <span class="dropdown-icon">
             <i class="fas fa-times-circle"></i>
         </span>

--- a/otterwiki/templates/editor.html
+++ b/otterwiki/templates/editor.html
@@ -50,7 +50,25 @@
   </div>
 </div>
 {##}
-<button onclick="otterwiki_editor.code()" class="btn btn-editor btn-xs hidden-sm-and-down" title="Code"><i class="fa fa-code"></i></button>
+<div class="dropdown">
+  <button class="btn btn-editor ml-5 hidden-sm-and-down" data-toggle="dropdown" type="button" id="navbar-dropdown-toggle-code" title="Code Menu">
+    <i class="fas fa-code"></i>
+  </button>
+  <div class="dropdown-menu dropdown-menu-right w-150" aria-labelledby="navbar-dropdown-toggle-code">
+    <a onclick="otterwiki_editor.code()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-code"></i>
+        </span>
+        Code element
+    </a>
+    <a onclick="otterwiki_editor.codeBlock()" href="#" class="dropdown-item-with-icon">
+        <span class="dropdown-icon">
+            <i class="fas fa-code"></i>
+        </span>
+        Code block
+    </a>
+  </div>
+</div>
 <button onclick="otterwiki_editor.quote()" class="btn btn-editor btn-xs hidden-sm-and-down" title="Block Quote"><i class="fa fa-quote-left"></i></button>
 <button onclick="otterwiki_editor.header()" class="btn btn-editor btn-xs ml-5 hidden-sm-and-down" title="Header"><i class="fa fa-heading"></i></button>
 {##}


### PR DESCRIPTION
Hi all

This is the PR mentioned in #191 .

**Functionality added to the editor button menu**:

- Block quotes (with support for multiple levels)
- Code blocks (multiline "` ``` `" blocks)
- Spoiler blocks (with support for multiple levels)
- Expands/Foldable blocks
- Alert blocks (note, tip, warning, etc.)
- Panels (the "fancy blocks" with colored background)
- Mermaid diagram quick button (adds a code block with the mermaid keyword)

**Functionality I am still working on**:
- Footnotes

**Changes to the original code**:
- I slightly rearranged the buttons in the menu. I tried grouping elements together that resemble each other.
- Refactoring of the multiple levels function previously only used by `header` -> I called it `_toggleLinesMultiLevel
- Slight convenience changes like refactoring magic numbers to constants (maximum multi level indentation, character for "line end")

**What I am unsure about**:
- I am not very happy with some of the icons that I chose for the new menu entries. Maybe someone else has better ideas?
- In multiple functions there is the variable `token` but it is not actually used, as far as I could tell. Should I add this parameter to the new functions as well?
- For footnotes it would be useful to be able to alert the user in case they selected multiple lines, because this won't work. I don't think there is such functionality yet?


I am happy to receive feedback on everything this PR adds/changes :slightly_smiling_face: 

When I am done with the code, I will squash the commits. Let me know if I shall squash them sooner.

