### PR TITLE
Frontmatter Plugin / Page Properties!

### DIFF
--- a/otterwiki/renderer.py
+++ b/otterwiki/renderer.py
@@ -27,6 +27,7 @@ from otterwiki.renderer_plugins import (
     plugin_math,
     plugin_alerts,
     plugin_wikilink,
+    plugin_frontmatter,
 )
 from otterwiki.plugins import chain_hooks
 from bs4 import BeautifulSoup
@@ -332,6 +333,7 @@ class OtterwikiRenderer:
                 plugin_math,
                 plugin_alerts,
                 plugin_wikilink,
+                plugin_frontmatter,
             ],
             env=self.env,
         )

--- a/otterwiki/renderer.py
+++ b/otterwiki/renderer.py
@@ -28,6 +28,7 @@ from otterwiki.renderer_plugins import (
     plugin_alerts,
     plugin_wikilink,
     plugin_frontmatter,
+    plugin_frontmatter_title,
 )
 from otterwiki.plugins import chain_hooks
 from bs4 import BeautifulSoup
@@ -334,6 +335,7 @@ class OtterwikiRenderer:
                 plugin_alerts,
                 plugin_wikilink,
                 plugin_frontmatter,
+                plugin_frontmatter_title,
             ],
             env=self.env,
         )

--- a/otterwiki/renderer_plugins.py
+++ b/otterwiki/renderer_plugins.py
@@ -651,6 +651,37 @@ class mistunePluginWikiLink:
             md.renderer.register('wikilink', self.render_html_wikilink)
 
 
+class mistunePluginFrontmatter:
+    FRONTMATTER_PATTERN = re.compile(r'^---\n(.*?)\n---', re.DOTALL)
+
+    def parse_frontmatter(self, block, m, state):
+        frontmatter = m.group(1)
+        return {
+            'type': 'frontmatter',
+            'text': frontmatter,
+        }
+
+    def render_html_frontmatter(self, text):
+        text = text.strip()
+        return f'''
+        <details class="collapse-panel" id="frontmatter">
+            <summary class="collapse-header">Properties</summary>
+            <div class="collapse-content">
+                <pre>{text}</pre>
+            </div>
+        </details>
+        '''
+
+    def __call__(self, md):
+        md.block.register_rule(
+            'frontmatter', self.FRONTMATTER_PATTERN, self.parse_frontmatter
+        )
+        md.block.rules.insert(0, 'frontmatter')  # Ensure it runs early
+
+        if md.renderer.NAME == 'html':
+            md.renderer.register('frontmatter', self.render_html_frontmatter)
+
+
 plugin_task_lists = mistunePluginTaskLists()
 plugin_footnotes = mistunePluginFootnotes()
 plugin_mark = mistunePluginMark()
@@ -660,3 +691,4 @@ plugin_fold = mistunePluginFold()
 plugin_math = mistunePluginMath()
 plugin_alerts = mistunePluginAlerts()
 plugin_wikilink = mistunePluginWikiLink()
+plugin_frontmatter = mistunePluginFrontmatter()

--- a/otterwiki/static/css/otterwiki.css
+++ b/otterwiki/static/css/otterwiki.css
@@ -63,6 +63,43 @@ h5:hover a.anchor {
     margin-block-end: 0rem !important;
 }
 
+
+/* frontmatter */
+
+/* Arrow */
+.collapse-header:not(.without-arrow),
+.collapse-panel[open] .collapse-header:not(.without)
+{
+    background-position: 0px !important;
+    position: relative; 
+    left: -12px;
+}
+
+/* Properties Text */
+#frontmatter .collapse-header {
+	padding: 0 0 0 1.3rem;
+	margin-bottom: 0rem;
+}
+/* Remove underline (Cleaner) */
+body #page-wrapper .collapse-header, 
+body #page-wrapper .collapse-header:focus {
+    border-bottom: 0px solid green !important;
+}
+
+.page #frontmatter pre {
+	padding: .7rem .7rem !important;
+	margin-left: 0rem;
+	margin-block-start: .2rem !important;
+    margin-block-end: 0rem !important;
+    background: rgba(0, 0, 0, 0.09);
+}
+.page #frontmatter,
+.page #frontmatter pre a {
+	color: #ddd;
+}	
+
+
+
 /* pre and code */
 
 div.page > div.highlight {

--- a/otterwiki/static/custom/custom.css
+++ b/otterwiki/static/custom/custom.css
@@ -7,3 +7,33 @@
  * see https://otterwiki.com/Customization for examples.
  *
 */
+// Arrow
+.collapse-header:not(.without-arrow),
+.collapse-panel[open] .collapse-header:not(.without),
+{
+    background-position: 0px !important;
+    position: relative; 
+    left: -12px;
+}
+// Properties Text
+#frontmatter .collapse-header {
+	padding: 0 0 0 1.3rem;
+	margin-bottom: 0rem;
+}
+// Remove underline (Cleaner)
+body #page-wrapper .collapse-header, 
+body #page-wrapper .collapse-header:focus {
+    border-bottom: 0px solid green !important;
+}
+
+.page #frontmatter pre {
+	padding: .7rem .7rem !important;
+	margin-left: 0rem;
+	margin-block-start: .2rem !important;
+    margin-block-end: 0rem !important;
+    background: rgba(0, 0, 0, 0.09);
+}
+.page #frontmatter,
+.page #frontmatter pre a {
+	color: #ddd;
+}	

--- a/otterwiki/static/custom/custom.css
+++ b/otterwiki/static/custom/custom.css
@@ -7,7 +7,7 @@
  * see https://otterwiki.com/Customization for examples.
  *
 */
-// Arrow
+
 .collapse-header:not(.without-arrow),
 .collapse-panel[open] .collapse-header:not(.without),
 {


### PR DESCRIPTION
## Solution
Simple Frontmatter display that toggles & is hidden by default (See more ideas below the image)

## Why
- Frontmatter / page properties supported by most markdown editors in the world
- We had a team repo we wanted to try collaborating on with the basic properties (seen in the below gif) but when we tried to sync it with Otter it wasn't parsed and created a real mess and this made me sad so wanted to fix because Otter is otherwise so great. 

![Otter FrontMatter](https://github.com/user-attachments/assets/ca756f19-18af-4c3e-8554-1be944db5811)

## More ideas
- Could add something to selectively remove completely from a page if something like `properties: false` is set at the page level AND could (probably should) made this a global setting inside editing settings like, "Hide/show page properties" ..... this would not impact people who don't even know what frontmatter is and wouldn't change appearance of anyone's existing site. 
- Inspirations on design here from the way Obsidian does it in a little toggle ... basically the most popular markdown tool in the world right now, I think, so they are probably make good design decisions
- Piggybacked on existing toggle js used to hide/show content in another plugin and modified the css slightly
- CSS was stuffed in custom but should, of course, be worked into core if someone agrees this should be a core feature

### Larger Screenshot
But see the above gif for behavior on click ... 

![Otter Wiki Frontmatter](https://github.com/user-attachments/assets/8ac1eb13-329d-44b1-b150-7c94d5100b82)

