### PR TITLE
Disable certain hotkeys in editable controls on mobile browsers

### DIFF
--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -1161,8 +1161,9 @@ var MathJax = {
 
 /* Hot Keys */
 window.addEventListener("keydown", function() {
-    var isInputElement = event.srcElement instanceof HTMLInputElement;
-    var isTextAreaElement = event.srcElement instanceof HTMLTextAreaElement;
+    let tagName = event.target.tagName.toLowerCase();
+    let isContentEditable = event.target.isContentEditable;
+    let isEditable = (tagName === 'input' || tagName === 'textarea' || isContentEditable);
 
     if (document.getElementById("save-page-btn") != null && (event.ctrlKey || event.metaKey) && event.key === 's') {
         event.preventDefault();
@@ -1181,7 +1182,7 @@ window.addEventListener("keydown", function() {
         }
     }
 
-    if(isInputElement || isTextAreaElement) {
+    if(isEditable) {
         return;
     }
 

--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -1161,9 +1161,12 @@ var MathJax = {
 
 /* Hot Keys */
 window.addEventListener("keydown", function() {
+    let isInputElement = event.srcElement instanceof HTMLInputElement;
+    let isTextAreaElement = event.srcElement instanceof HTMLTextAreaElement;
     let tagName = event.target.tagName.toLowerCase();
     let isContentEditable = event.target.isContentEditable;
-    let isEditable = (tagName === 'input' || tagName === 'textarea' || isContentEditable);
+    // I'm a bit paranoid here, want to be sure that nothing is missed again
+    let isEditable = (isInputElement || isTextAreaElement || tagName === 'input' || tagName === 'textarea' || isContentEditable);
 
     if (document.getElementById("save-page-btn") != null && (event.ctrlKey || event.metaKey) && event.key === 's') {
         event.preventDefault();


### PR DESCRIPTION
Hi @redimp, I found a bug with the new create page hotkey on mobile devices:

Steps to reproduce:
1. Navigate to any page in a mobile browser
2. Edit the page
3. Anywhere in the edit window, type the c character

Expected behavior: The c character is entered in the edit box at the cursor's position
Actual behavior: The browser navigates to the create page

I tested the fix in Safari and Chrome on iOS.