### PR TITLE
fixes potential issues with dates of attachment headers:

### DIFF
--- a/otterwiki/wiki.py
+++ b/otterwiki/wiki.py
@@ -1337,7 +1337,7 @@ class Attachment:
             # set header, caching, etc
             response.headers["Last-Modified"] = http_date(metadata['datetime'])
             response.headers["Cache-Control"] = "max-age=604800, immutable"
-            response.headers["Date"] = http_date(self.datetime.utctimetuple())
+            response.headers["Date"] = http_date(datetime.now(UTC))
 
         return response
 
@@ -1368,13 +1368,14 @@ class Attachment:
             )
         )
         # build response
+        now_utc = datetime.now(UTC)
         response = make_response(send_file(buffer, mimetype=self.mimetype))
-        response.headers["Date"] = http_date(self.datetime.utctimetuple())
+        response.headers["Date"] = http_date(now_utc)
         response.headers["Expires"] = http_date(
-            (self.datetime + timedelta(hours=1)).utctimetuple()
+            (now_utc + timedelta(hours=1)).astimezone(UTC)
         )
         response.headers["Last-Modified"] = http_date(
-            self.datetime.utctimetuple()
+            self.datetime.astimezone(UTC)
         )
 
         return response


### PR DESCRIPTION
Addresses #231

1. Sets the Date header to always be the server's current time ([following the spec](https://datatracker.ietf.org/doc/html/rfc2616#section-14.18))
2. sets expires header to 1 hour in the future from the current time (before expires header could be in the past!)
3. sets last-modified time to the correct UTC time using `astimezone(UTC)`

Tests passing

```sh
======================================================================== test session starts =========================================================================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/defron/src/otterwiki
configfile: pyproject.toml
collected 186 items                                                                                                                                                  

tests/test_attachments.py .........                                                                                                                            [  4%]
tests/test_auth.py .............................                                                                                                               [ 20%]
tests/test_draft.py ...                                                                                                                                        [ 22%]
tests/test_essentials.py ....                                                                                                                                  [ 24%]
tests/test_gitstorage.py ......................                                                                                                                [ 36%]
tests/test_helper.py ...............                                                                                                                           [ 44%]
tests/test_otterwiki.py .....................                                                                                                                                                                  [ 55%]
tests/test_preferences.py .............                                                                                                                        [ 62%]
tests/test_preview.py .....                                                                                                                                    [ 65%]
tests/test_remote.py ......                                                                                                                                    [ 68%]
tests/test_renderer.py ....................................                                                                                                    [ 87%]
tests/test_settings.py ...                                                                                                                                     [ 89%]
tests/test_sidebar.py ....                                                                                                                                     [ 91%]
tests/test_util.py ................                                                                                                                            [100%]

======================================================================== 186 passed in 15.90s ========================================================================
```