### PR TITLE
Initial Type hinting: setting things up to gradually enable stricter type hinting

### DIFF
--- a/otterwiki/__init__.py
+++ b/otterwiki/__init__.py
@@ -2,6 +2,7 @@
 # vim: set et ts=8 sts=4 sw=4 ai:
 
 import sys
+
 from .version import __version__
 
 __all__ = ["fatal_error"]

--- a/otterwiki/__init__.py
+++ b/otterwiki/__init__.py
@@ -8,6 +8,6 @@ from .version import __version__
 __all__ = ["fatal_error"]
 
 
-def fatal_error(msg):
+def fatal_error(msg: str | Exception):
     print("\nError: {}\n".format(msg), file=sys.stderr)
     sys.exit(1)

--- a/otterwiki/gitstorage.py
+++ b/otterwiki/gitstorage.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import re
 from datetime import datetime
+from typing import List, cast
 
 import git
 import git.exc
@@ -140,7 +141,12 @@ class GitStorage(object):
         blamedata = []
         metadata_cache = {}
         n = 1
-        for commit, lines in commits:
+        # blame can return an iterable blame if incremental=True
+        # casting to keep it obvious we aren't doing that
+        # can be removed if gitpython adds an overload on incremental
+        for commit, lines in cast(
+            List[List[git.Commit | List[str | bytes] | None]], commits
+        ):
             try:
                 metadata = metadata_cache[commit]
             except KeyError:
@@ -264,7 +270,14 @@ class GitStorage(object):
         # build and return logfile
         return [self._get_metadata_of_commit(commit) for commit in commits]
 
-    def store(self, filename, content, message="", author=("", ""), mode="w"):
+    def store(
+        self,
+        filename,
+        content,
+        message: str | None = "",
+        author=("", ""),
+        mode="w",
+    ):
         if message is None:
             message = ""
         dirname = os.path.dirname(filename)

--- a/otterwiki/gitstorage.py
+++ b/otterwiki/gitstorage.py
@@ -2,13 +2,14 @@
 # vim: set et ts=8 sts=4 sw=4 ai:
 
 import os
+import pathlib
 import re
+from datetime import datetime
+
 import git
 import git.exc
-from datetime import datetime
+
 from otterwiki.util import split_path, ttl_lru_cache
-import pathlib
-import os
 
 
 class StorageError(Exception):

--- a/otterwiki/helper.py
+++ b/otterwiki/helper.py
@@ -11,10 +11,8 @@ lightweight as utils.
 
 import os
 import re
-import os
 from hashlib import sha256
 import json
-from datetime import datetime
 from collections import namedtuple
 from otterwiki.server import app, mail, storage, Preferences, db, app_renderer
 from otterwiki.gitstorage import StorageError
@@ -23,7 +21,6 @@ from threading import Thread
 from flask_mail import Message
 from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
 from otterwiki.util import split_path, join_path, clean_slashes, titleSs
-from otterwiki.renderer import OtterwikiRenderer
 from otterwiki.models import Cache
 
 

--- a/otterwiki/plugins.py
+++ b/otterwiki/plugins.py
@@ -10,8 +10,6 @@ See docs/plugin_examples for examples.
 """
 
 import pluggy
-import re
-import urllib.parse
 
 hookspec = pluggy.HookspecMarker("otterwiki")
 hookimpl = pluggy.HookimplMarker("otterwiki")

--- a/otterwiki/preferences.py
+++ b/otterwiki/preferences.py
@@ -4,6 +4,8 @@
 import re
 import json
 from datetime import datetime
+from typing import cast
+from otterwiki.models import User
 from otterwiki.util import is_valid_email
 from flask import (
     redirect,
@@ -405,8 +407,8 @@ def user_edit_form(uid):
 def handle_user_add(form):
     if not has_permission("ADMIN"):
         abort(403)
-    # get empty user object
-    user = get_user(None)
+    # get empty user object, it will never be null
+    user = cast(User, get_user(None))
     # update user from form
     user.name = form.get("name").strip()  # pyright: ignore
     user.email = form.get("email").strip()  # pyright: ignore

--- a/otterwiki/remote.py
+++ b/otterwiki/remote.py
@@ -10,7 +10,7 @@ from otterwiki.auth import current_user, has_permission, check_credentials
 
 
 class GitHttpServer:
-    def __init__(self, path):
+    def __init__(self, path: str):
         self.path = path
         # configure git to allow pushing into the current branch
         # of the non-bare repository, see https://git-scm.com/docs/git-config#Documentation/git-config.txt-receivedenyCurrentBranch

--- a/otterwiki/renderer.py
+++ b/otterwiki/renderer.py
@@ -281,7 +281,9 @@ class OtterwikiBlockParser(mistune.BlockParser):
         """
         raw = m.group(1)
         text = mistune.block_parser.expand_leading_tab(raw)
-        code = mistune.block_parser._INDENT_CODE_TRIM.sub('', text)
+        code = mistune.block_parser._INDENT_CODE_TRIM.sub(  # pyright: ignore
+            '', text
+        )
         code = code.lstrip('\n')
         return self.tokenize_block_code(code, None, state)
 

--- a/otterwiki/renderer.py
+++ b/otterwiki/renderer.py
@@ -4,34 +4,29 @@
 import re
 
 import mistune
-from mistune.plugins import (
-    plugin_table,
-    plugin_url,
-    plugin_strikethrough,
-)
-
+from bs4 import BeautifulSoup
+from markupsafe import Markup, escape
+from mistune.plugins import plugin_strikethrough, plugin_table, plugin_url
 from pygments import highlight
-from pygments.lexers import get_lexer_by_name
 from pygments.formatters import html
+from pygments.lexers import get_lexer_by_name
 from pygments.util import ClassNotFound
 
-from markupsafe import Markup, escape
-from otterwiki.util import slugify, empty
+from otterwiki.plugins import chain_hooks
 from otterwiki.renderer_plugins import (
-    plugin_task_lists,
+    plugin_alerts,
+    plugin_fancy_blocks,
+    plugin_fold,
     plugin_footnotes,
     plugin_mark,
-    plugin_fancy_blocks,
-    plugin_spoiler,
-    plugin_fold,
     plugin_math,
-    plugin_alerts,
+    plugin_spoiler,
+    plugin_task_lists,
     plugin_wikilink,
     plugin_frontmatter,
     plugin_frontmatter_title,
 )
-from otterwiki.plugins import chain_hooks
-from bs4 import BeautifulSoup
+from otterwiki.util import empty, slugify
 
 # the cursor magic word which is ignored by the rendering
 cursormagicword = "CuRsoRm4g1cW0Rd"

--- a/otterwiki/server.py
+++ b/otterwiki/server.py
@@ -111,9 +111,9 @@ else:
 
 
 # check if the git repository is empty
-if (len(storage.list()[0]) < 1) and (
-    len(storage.log()) < 1
-):  # pyright: ignore
+if (len(storage.list()[0]) < 1) and (  # pyright: ignore never unbound
+    len(storage.log()) < 1  # pyright: ignore
+):
     # we have a brand new repository here
     with open(os.path.join(app.root_path, "initial_home.md")) as f:
         content = f.read()
@@ -228,4 +228,6 @@ import otterwiki.remote
 
 githttpserver = otterwiki.remote.GitHttpServer(path=app.config["REPOSITORY"])
 
-import otterwiki.views
+# contains application routes,
+# using side-effect of import executing the file to get
+import otterwiki.views  # pyright: ignore

--- a/otterwiki/server.py
+++ b/otterwiki/server.py
@@ -196,7 +196,7 @@ for plugin, dist in plugininfo:
 # template extensions
 #
 @app.template_filter("debug_unixtime")
-def template_debug_unixtime(s):
+def template_debug_unixtime(s: int) -> str:
     if app.debug:
 
         return "{}?{}".format(s, datetime.datetime.now().strftime("%s"))
@@ -205,7 +205,7 @@ def template_debug_unixtime(s):
 
 
 @app.template_filter("format_datetime")
-def format_datetime(value, format="medium"):
+def format_datetime(value: datetime.datetime, format="medium") -> str:
     if format == "medium":
         format = "%Y-%m-%d %H:%M"
     if format == "deltanow":

--- a/otterwiki/server.py
+++ b/otterwiki/server.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python
 # vim: set et ts=8 sts=4 sw=4 ai:
 
+import datetime
 import os
 import sys
-import logging
-import datetime
+
 from flask import Flask
 from flask_mail import Mail
 from flask_sqlalchemy import SQLAlchemy
-from otterwiki import fatal_error, __version__
+
 import otterwiki.gitstorage
 import otterwiki.util
+from otterwiki import __version__, fatal_error
 from otterwiki.plugins import plugin_manager
 from otterwiki.renderer import OtterwikiRenderer
 

--- a/otterwiki/util.py
+++ b/otterwiki/util.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python
 # vim: set et ts=8 sts=4 sw=4 ai:
 
+import datetime
+import mimetypes
 import os.path
 import pathlib
-import re
-import unicodedata
-from email.utils import parseaddr
 import random
+import re
 import string
-import mimetypes
 import time
-import datetime
+import unicodedata
 from functools import lru_cache
 
 

--- a/otterwiki/util.py
+++ b/otterwiki/util.py
@@ -11,6 +11,7 @@ import string
 import time
 import unicodedata
 from functools import lru_cache
+from typing import List
 
 
 def ttl_lru_cache(ttl: int = 60, maxsize: int = 128):
@@ -86,7 +87,7 @@ def sanitize_pagename(value, allow_unicode=True):
     return value
 
 
-def split_path(path):
+def split_path(path: str) -> List[str]:
     if path == "":
         return []
     head = os.path.dirname(path)
@@ -114,12 +115,12 @@ def get_pagepath(pagename):
     return pagename
 
 
-def get_page_directoryname(pagepath):
+def get_page_directoryname(pagepath: str) -> str:
     parts = split_path(pagepath)
     return join_path(parts[:-1])
 
 
-def join_path(path_arr):
+def join_path(path_arr: List[str]) -> str:
     if len(path_arr) < 1:
         return ""
     return os.path.join(*path_arr)

--- a/otterwiki/views.py
+++ b/otterwiki/views.py
@@ -12,7 +12,7 @@ from flask import (
     redirect,
     url_for,
 )
-from otterwiki.server import app, storage, githttpserver
+from otterwiki.server import app, githttpserver
 from otterwiki.wiki import (
     Page,
     PageIndex,
@@ -25,7 +25,7 @@ import otterwiki.preferences
 from otterwiki.renderer import render
 from otterwiki.helper import toast, health_check, get_pagename_prefixes
 from otterwiki.version import __version__
-from otterwiki.util import sanitize_pagename, split_path, join_path
+from otterwiki.util import sanitize_pagename
 
 from flask_login import login_required
 

--- a/otterwiki/wiki.py
+++ b/otterwiki/wiki.py
@@ -6,6 +6,7 @@ import re
 from datetime import UTC, datetime, timedelta
 from io import BytesIO
 from timeit import default_timer as timer
+from typing import List, cast
 from urllib.parse import unquote
 
 import PIL.Image
@@ -240,7 +241,7 @@ class Changelog:
         for orig_entry in storage.log():
             entry = dict(orig_entry)
             entry["files"] = {}
-            for filename in orig_entry["files"]:
+            for filename in cast(List[str], orig_entry["files"]):
                 entry["files"][filename] = {}
                 (
                     entry["files"][filename]["name"],
@@ -1482,7 +1483,7 @@ class Search:
                 summary = [matches.pop(0)]
                 # overwrite key[4]
                 key[4] = self.rei.sub(
-                    r'<span class="page-match">\1</span>', key[4]
+                    r'<span class="page-match">\1</span>', cast(str, key[4])
                 )
             front, end = [], []
             while len("".join(front) + "".join(end)) < 200:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ dev = [
     "rjsmin",
     "git-changelog",
     "pre-commit",
-    ]
+    "types-Flask>=1.1.6",
+]
 
 [build-system]
 requires = [
@@ -98,6 +99,23 @@ filterwarnings = [
 [tool.pyright]
 venvPath = "."
 venv = "venv"
+typeCheckingMode = "strict"
+reportMissingImports = "error"
+reportUnnecessaryComparison = "error" # debatably a warning, but there are a few
+reportUntypedFunctionDecorator = "warning"
+reportUnusedExpression = "warning"
+reportUnusedVariable = "warning"
+reportUntypedNamedTuple = "warning"
+reportMissingTypeArgument = "information"
+reportMissingTypeStubs = false
+reportUnknownMemberType = false
+reportUnknownVariableType = false
+reportAttributeAccessIssue = false
+reportUnknownParameterType = false
+reportMissingParameterType = false
+reportUnknownArgumentType = false
+reportCallIssue = false
+reportUnknownLambdaType = false
 
 [tool.git-changelog]
 bump = "auto"


### PR DESCRIPTION
Initial Type hinting: setting things up to gradually enable stricter type hinting as part of #229 

* Individual changes are grouped together on commits. If there are any objections to any changes it should be easy to revert that specific commit
* added dev dependency "types-Flask" for Flask types stubs
* added to tool.pyright relaxed type enforcement settings
* cleaned up ans sorted imports, removing unused imports to make pyright happy
* added some basic type hints on areas that it made sense, as well as added some [casting](https://docs.python.org/3/library/typing.html#typing.cast) to help pyright know what types things are when ambiguous
* added pyright ignore on use of private vars in overwritten mistune code indent method
* added pyright ignore to the import of otterwiki.views since the import itself is adding the routes and views
* handfle some possible None scenarios returned from gitpython related to blame, split log lines to be stored in a separate variable to keep type hints clean

Notes:

I'd like to slowly flip on the pyright settings set to false to warn/error based on what makes sense as type hinting work continues.

There are two cases where pyright shows an error currently because I didn't want to make a code change and didn't want to relax the rule, both are related to the rule [reportUnnecessaryComparison](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportUnnecessaryComparison):

*otterwiki/wiki.py L267: commit_count is explicitly set to 100 on line 235 and never changed, so it can never be None
* otterwiki/sidebar.pyL175: path will always be at worst an empty string (confirming this was where most of the current type hints are from) so never None

Tests:

```sh
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/defron/src/otterwiki
configfile: pyproject.toml
collected 187 items

tests/test_attachments.py .........                                      [  4%]
tests/test_auth.py .............................                         [ 20%]
tests/test_draft.py ...                                                  [ 21%]
tests/test_essentials.py ....                                            [ 24%]
tests/test_gitstorage.py ......................                          [ 35%]
tests/test_helper.py ...............                                     [ 43%]
tests/test_otterwiki.py .....................                            [ 55%]
tests/test_preferences.py .............                                  [ 62%]
tests/test_preview.py .....                                              [ 64%]
tests/test_remote.py ......                                              [ 67%]
tests/test_renderer.py .....................................             [ 87%]
tests/test_settings.py ...                                               [ 89%]
tests/test_sidebar.py ....                                               [ 91%]
tests/test_util.py ................                                      [100%]

============================= 187 passed in 15.98s =============================
```