### PR TITLE
Disable hotkeys [ and / when modifiers are enabled

### DIFF
--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -1189,12 +1189,12 @@ window.addEventListener("keydown", function() {
         return;
     }
 
-	if (document.getElementById("search-query") != null && event.key === '/') {
+	if (document.getElementById("search-query") != null && event.key === '/' && !(event.ctrlKey || event.metaKey || event.altKey || event.shiftKey)) {
         document.getElementById("search-query").focus();
         event.preventDefault();
     }
 
-    if (document.getElementById("toggle-sidebar-btn") != null && event.key === '[') {
+    if (document.getElementById("toggle-sidebar-btn") != null && event.key === '[' && !(event.ctrlKey || event.metaKey || event.altKey || event.shiftKey)) {
         event.preventDefault();
         document.getElementById("toggle-sidebar-btn").click();
     }


### PR DESCRIPTION
Greetings!  This PR fixes an issue with the '[' hotkey that prevented users from pressing the common browser hotkey Cmd + [ to navigate to the previous page.

Steps to rep:
* Open any otter wiki page
* Press Cmd + [ or Ctrl + [ depending on OS

Expected behavior: the browser should navigate to the previously opened page
Actual behavior: the sidebar is toggled

This change updates the [ and / hotkeys so they are only active when no modifier keys are pressed.  I did not personally have an issue with the / hotkey, but it seemed prudent to apply the change there as well.  I've been running this locally for a few days without issue but please let me know if you run into anything.