### PR TITLE
Author plugin shows creator and last modified metadata

### DIFF
--- a/docs/plugin_examples/README.md
+++ b/docs/plugin_examples/README.md
@@ -25,6 +25,9 @@ the volume that keeps the `app-data`, where also the `db.sqlite` and the
 `repostitory` lives. Or you organize the plugins in a separate directory
 which you mount in the container into `/plugins`.
 
+In environments with `SELINUX=enforcing` the bind mounts have to be adjusted,
+please check the [FAQ](https://otterwiki.com/FAQ#environments-with-selinux).
+
 *Note:* For plugins with complex dependencies the docker image might be missing
 packages. In this case adding these packages to the image is inevitable, a
 custom image (which packs the plugin, too) might be the best solution.
@@ -32,4 +35,3 @@ custom image (which packs the plugin, too) might be the best solution.
 ### Demo of the example plugins
 
 You can find a `docker-compose.yaml` in [docs/plugin_examples](https://github.com/redimp/otterwiki/tree/main/docs/plugin_examples).
-

--- a/docs/plugin_examples/plugin_authorsignature/otterwiki_authorsignature.py
+++ b/docs/plugin_examples/plugin_authorsignature/otterwiki_authorsignature.py
@@ -13,9 +13,14 @@ from otterwiki.plugins import hookimpl
 @hookimpl
 def page_view_htmlcontent_postprocess(html, page, storage):
     if page.metadata is not None:
+        # Getting the first sha of the page file to request the metadata to be used
+        # for the page creation info.
+        first_sha = storage.repo.git.rev_list("--max-parents=0", "HEAD", page.filename)
+        creation_metadata = storage.metadata(page.filename, first_sha)
         html += f"""
         <div style="margin-top: 5rem; padding-top: .5rem; border-top: 1px dashed rgba(128,128,128,0.2); color: rgba(128,128,128,0.5);" class="text-small">
-            Last modified {page.metadata["datetime"].strftime("%Y-%m-%d %H:%M:%S")} by {page.metadata["author_name"]}
+            Last modified {page.metadata["datetime"].strftime("%Y-%m-%d %H:%M:%S")} by {page.metadata["author_name"]}.
+            <br \>Created {creation_metadata['datetime'].strftime("%Y-%m-%d %H:%M:%S")} by {creation_metadata['author_name']}.
         </div>
         """
     return html

--- a/docs/plugin_examples/plugin_authorsignature/otterwiki_authorsignature.py
+++ b/docs/plugin_examples/plugin_authorsignature/otterwiki_authorsignature.py
@@ -11,7 +11,7 @@ from otterwiki.plugins import hookimpl
 
 
 @hookimpl
-def page_view_htmlcontent_postprocess(html, page):
+def page_view_htmlcontent_postprocess(html, page, storage):
     if page.metadata is not None:
         html += f"""
         <div style="margin-top: 5rem; padding-top: .5rem; border-top: 1px dashed rgba(128,128,128,0.2); color: rgba(128,128,128,0.5);" class="text-small">

--- a/docs/plugin_examples/plugin_authorsignature/otterwiki_authorsignature.py
+++ b/docs/plugin_examples/plugin_authorsignature/otterwiki_authorsignature.py
@@ -3,24 +3,40 @@
 """
 This is an example plugin for An Otter Wiki.
 
-The hook is a function that formats and appends some metadata
-to the rendered page html.
+The hook is inside a class named AuthorSignature.
+
+This class is making use of the setup() hook which gives the plugin access to
+An Otter Wikis core objects: The Flask app, the database and the storage.
+
+Note: To make the plugin_manager find it, the class has to be registered.
 """
 
-from otterwiki.plugins import hookimpl
+from otterwiki.plugins import hookimpl, plugin_manager
 
 
-@hookimpl
-def page_view_htmlcontent_postprocess(html, page, storage):
-    if page.metadata is not None:
-        # Getting the first sha of the page file to request the metadata to be used
-        # for the page creation info.
-        first_sha = storage.repo.git.rev_list("--max-parents=0", "HEAD", page.filename)
-        creation_metadata = storage.metadata(page.filename, first_sha)
-        html += f"""
-        <div style="margin-top: 5rem; padding-top: .5rem; border-top: 1px dashed rgba(128,128,128,0.2); color: rgba(128,128,128,0.5);" class="text-small">
-            Last modified {page.metadata["datetime"].strftime("%Y-%m-%d %H:%M:%S")} by {page.metadata["author_name"]}.
-            <br \>Created {creation_metadata['datetime'].strftime("%Y-%m-%d %H:%M:%S")} by {creation_metadata['author_name']}.
-        </div>
-        """
-    return html
+class AuthorSignature:
+    @hookimpl
+    def setup(
+        self, app, db, storage
+    ) -> None:  # pyright: ignore [reportUnusedVariable]
+        self.storage = storage
+
+    @hookimpl
+    def page_view_htmlcontent_postprocess(self, html, page):
+        if page.metadata is not None:
+            # Getting the first sha of the page file to request the metadata to be used
+            # for the page creation info.
+            first_sha = self.storage.repo.git.rev_list(
+                "--max-parents=0", "HEAD", page.filename
+            )
+            creation_metadata = self.storage.metadata(page.filename, first_sha)
+            html += f"""
+            <div style="margin-top: 5rem; padding-top: .5rem; border-top: 1px dashed rgba(128,128,128,0.2); color: rgba(128,128,128,0.5);" class="text-small">
+                Last modified {page.metadata["datetime"].strftime("%Y-%m-%d %H:%M:%S")} by {page.metadata["author_name"]}.
+                <br/>Created {creation_metadata['datetime'].strftime("%Y-%m-%d %H:%M:%S")} by {creation_metadata['author_name']}.
+            </div>
+            """
+        return html
+
+
+plugin_manager.register(AuthorSignature())

--- a/docs/plugin_examples/plugin_authorsignature/pyproject.toml
+++ b/docs/plugin_examples/plugin_authorsignature/pyproject.toml
@@ -4,10 +4,11 @@ build-backend = "hatchling.build"
 
 [project]
 name = "otterwiki_authorsignature"
-description = "An example plugin for An Otter Wiki that modifies the page view."
-version  = "0.1.0"
+description = "An example plugin for An Otter Wiki that modifies the page view by adding a footer with the original author and last saved editor."
+version  = "0.2.0"
 authors = [
-    { name = "Ralph Thesen", email = "mail@redimp.de" }
+    { name = "Ralph Thesen", email = "mail@redimp.de" },
+    { name = "Ben Esquivel", email = "tarxf@esquibits.com"}
     ]
 
 [project.entry-points.otterwiki]

--- a/otterwiki/plugins.py
+++ b/otterwiki/plugins.py
@@ -19,7 +19,17 @@ class OtterWikiPluginSpec:
     """A hook specification namespace for OtterWiki."""
 
     @hookspec
-    def renderer_markdown_preprocess(self, md):
+    def setup(self, app, db, storage) -> None:
+        """
+        This hook receives the core objects and is to be used to
+        initialize the plugin with the app, database, and storage.
+        """
+        self.app = app
+        self.db = db
+        self.storage = storage
+
+    @hookspec
+    def renderer_markdown_preprocess(self, md: str) -> str | None:
         """
         This hook receives a markdown string, and can transform it any way it
         sees fit. It is called before the markdown is rendered into HTML.
@@ -29,14 +39,14 @@ class OtterWikiPluginSpec:
         """
 
     @hookspec
-    def renderer_html_postprocess(self, html):
+    def renderer_html_postprocess(self, html: str) -> str | None:
         """
         This hooks receive a html string. It is called after the pages
         markdown has been rendered into html.
         """
 
     @hookspec
-    def page_view_htmlcontent_postprocess(self, html, page, storage):
+    def page_view_htmlcontent_postprocess(self, html, page) -> str | None:
         """
         This hooks receives a html string containing the page content.
         """

--- a/otterwiki/plugins.py
+++ b/otterwiki/plugins.py
@@ -36,7 +36,7 @@ class OtterWikiPluginSpec:
         """
 
     @hookspec
-    def page_view_htmlcontent_postprocess(self, html, page):
+    def page_view_htmlcontent_postprocess(self, html, page, storage):
         """
         This hooks receives a html string containing the page content.
         """

--- a/otterwiki/server.py
+++ b/otterwiki/server.py
@@ -198,6 +198,10 @@ for plugin, dist in plugininfo:
     app.logger.info(
         f"server: Loaded plugin: {dist.project_name}-{dist.version}"
     )
+# setup plugins
+plugin_manager.hook.setup(
+    app=app, storage=storage, db=db
+)  # pyright: ignore never unbound
 
 
 #

--- a/otterwiki/util.py
+++ b/otterwiki/util.py
@@ -154,6 +154,26 @@ def empty(what):
     return False
 
 
+def int_or_None(in_val: any) -> int | None:
+    """
+    Accepts any parameter and attempts to cast it to an integer, rounding down.
+    If the cast is successful, it returns the integer.
+    If the cast fails, it returns None.
+
+    Args:
+        in_val: The parameter to be cast to an integer.
+
+    Returns:
+        The integer representation of the input, or None if the cast fails.
+    """
+    try:
+        return int(
+            float(in_val)
+        )  # Cast to float first, then to int, rounding down
+    except (ValueError, TypeError):
+        return None
+
+
 def guess_mimetype(path):
     mimetype, encoding = mimetypes.guess_type(path)
     if mimetype is None:

--- a/otterwiki/wiki.py
+++ b/otterwiki/wiki.py
@@ -687,7 +687,7 @@ class Page:
         menutree = SidebarPageIndex(get_page_directoryname(self.pagepath))
 
         htmlcontent = chain_hooks(
-            "page_view_htmlcontent_postprocess", htmlcontent, self, storage
+            "page_view_htmlcontent_postprocess", htmlcontent, self
         )
 
         # generate a description for the meta tag og:description

--- a/otterwiki/wiki.py
+++ b/otterwiki/wiki.py
@@ -687,7 +687,7 @@ class Page:
         menutree = SidebarPageIndex(get_page_directoryname(self.pagepath))
 
         htmlcontent = chain_hooks(
-            "page_view_htmlcontent_postprocess", htmlcontent, self
+            "page_view_htmlcontent_postprocess", htmlcontent, self, storage
         )
 
         # generate a description for the meta tag og:description

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -20,6 +20,7 @@ from otterwiki.util import (
     get_header,
     strfdelta_round,
     is_valid_name,
+    int_or_None,
 )
 
 
@@ -243,3 +244,17 @@ def test_strfdelta_round():
     assert (
         strfdelta_round(timedelta(days=21), round_period="minute") == "3 weeks"
     )
+
+
+def test_int_or_None():
+    assert int_or_None(10) == 10
+    assert int_or_None("20") == 20
+    assert int_or_None([1, 2]) is None
+    assert int_or_None(None) is None
+    assert int_or_None("abc") is None
+    assert int_or_None(3.14) == 3
+    assert int_or_None("") is None
+    assert int_or_None(True) == 1
+    assert int_or_None(False) == 0
+    assert int_or_None(10.9) == 10
+    assert int_or_None(2.7) == 2


### PR DESCRIPTION
Changes to include the author of the first commit of the file as 'creator' in the authorsignature plugin.

This is a simplistic approach that:

1. locates and appends the creator info in the metadata call from gitstorage.py. This is a choice that would be beneficial if the plan is to eventually promote the author footer into the page view. See alternate proposal below.
2. will miss the original author if the file is moved/renamed. It will show instead the author of the page move. This can be fixed but will require a bit more code and deciding if that's what should be done.

An **alternate proposal**, if the changes to gitstorage.py are invasive, is to instance a git repo object in the plugin and get the data there. If the author footer in the page is not planned to be integrated to the page natively, then this approach might be preferred.

Let me know your thoughts.

**Testing**

<img width="952" height="427" alt="Screenshot From 2025-08-19 11-24-46" src="https://github.com/user-attachments/assets/e91e6a9a-ba68-4612-9dc2-6fea18a70d30" />
