### PR TITLE
Fix: stop escaping anything when calling preview

### DIFF
--- a/otterwiki/templates/editor.html
+++ b/otterwiki/templates/editor.html
@@ -588,7 +588,7 @@ thx to https://github.com/sparksuite/simplemde-markdown-editor/issues/328#issuec
         formData.append("cursor_ch", cm_editor.getCursor().ch);
 
         /* FIXME: display loader */
-        fetch("{{ url_for('preview', path=pagepath) }}", {
+        fetch("{{ url_for('preview', path=pagepath) | safe }}", {
                 method: 'POST',
                 body: formData,
             })


### PR DESCRIPTION
This should fix #307.

My line of thought is the following: there is no point in escaping anything when calling a preview since it works with any page names, including the ones that don't exist and even can't exist, simply for building the breadcrumbs. XSS doesn't seem to be possible here either, because everything is being sanitized in the preview output anyway.