### PR TITLE
Setting to treat underscores as spaces for page titles

### DIFF
--- a/otterwiki/helper.py
+++ b/otterwiki/helper.py
@@ -206,6 +206,23 @@ def get_pagename(filepath, full=False, header=None):
     return "/".join(arr)
 
 
+def get_pagename_for_title(filepath, full=False, header=None):
+    '''this will derive the page name for display purposes (titles, breadcrumbs, etc.) with underscore replacement'''
+    pagename = get_pagename(filepath, full=full, header=header)
+
+    if app.config.get("TREAT_UNDERSCORE_AS_SPACE_FOR_TITLES", False):
+        if full:
+            # replace underscores in each path component
+            parts = pagename.split("/")
+            parts = [part.replace("_", " ") for part in parts]
+            return "/".join(parts)
+        else:
+            # replace underscores in the single component
+            return pagename.replace("_", " ")
+
+    return pagename
+
+
 def get_pagename_prefixes(filter=[]):
     pagename_prefixes = []
 
@@ -234,7 +251,7 @@ def get_breadcrumbs(pagepath):
         parents.append(e)
         crumbs.append(
             (
-                get_pagename(e),
+                get_pagename_for_title(e),
                 join_path(parents),
             )
         )

--- a/otterwiki/preferences.py
+++ b/otterwiki/preferences.py
@@ -18,7 +18,12 @@ from flask_login import (
 )
 from otterwiki.server import app, db, update_app_config, Preferences
 from otterwiki.sidebar import SidebarPageIndex, SidebarMenu
-from otterwiki.helper import toast, send_mail, get_pagename
+from otterwiki.helper import (
+    toast,
+    send_mail,
+    get_pagename,
+    get_pagename_for_title,
+)
 from otterwiki.util import empty, is_valid_email
 from flask_login import current_user
 from otterwiki.auth import (
@@ -180,6 +185,7 @@ def handle_content_and_editing(form):
     for checkbox in [
         "retain_page_name_case",
         "git_web_server",
+        "treat_underscore_as_space_for_titles",
     ]:
         _update_preference(checkbox.upper(), form.get(checkbox, "False"))
     # commit changes to the database
@@ -369,7 +375,7 @@ def sidebar_preferences_form():
     # we reuse SidebarPageIndex to generate a list of all pages
     sn = SidebarPageIndex("", mode="*")
     pages = [
-        get_pagename(fh[0], full=True, header=fh[1])
+        get_pagename_for_title(fh[0], full=True, header=fh[1])
         for fh in sn.filenames_and_header
     ]
     # render form

--- a/otterwiki/server.py
+++ b/otterwiki/server.py
@@ -67,6 +67,7 @@ app.config.update(
     HTML_EXTRA_HEAD="",
     HTML_EXTRA_BODY="",
     LOG_LEVEL_WERKZEUG="INFO",
+    TREAT_UNDERSCORE_AS_SPACE_FOR_TITLES=False,
 )
 app.config.from_envvar("OTTERWIKI_SETTINGS", silent=True)
 
@@ -164,6 +165,7 @@ def update_app_config():
                 "SIDEBAR_MENUTREE_IGNORE_CASE",
                 "GIT_WEB_SERVER",
                 "HIDE_LOGO",
+                "TREAT_UNDERSCORE_AS_SPACE_FOR_TITLES",
             ] or item.name.upper().startswith("SIDEBAR_SHORTCUT_"):
                 item.value = item.value.lower() in ["true", "yes"]
             if item.name.upper() in ["MAIL_PORT"]:

--- a/otterwiki/sidebar.py
+++ b/otterwiki/sidebar.py
@@ -15,6 +15,7 @@ from otterwiki.util import (
 )
 from otterwiki.helper import (
     get_pagename,
+    get_pagename_for_title,
 )
 
 
@@ -158,7 +159,7 @@ class SidebarPageIndex:
                     full=True,
                     header=header if len(parts) == 1 else None,
                 ),
-                "header": get_pagename(
+                "header": get_pagename_for_title(
                     join_path(prefix + parts),
                     full=False,
                     header=header if len(parts) == 1 else None,

--- a/otterwiki/templates/admin/content_and_editing.html
+++ b/otterwiki/templates/admin/content_and_editing.html
@@ -29,6 +29,18 @@
 {##}
     <div class="form-group">
       <div class="custom-checkbox">
+        <input {%if config.TREAT_UNDERSCORE_AS_SPACE_FOR_TITLES %}checked{% endif %} type="checkbox" id="treat_underscore_as_space_for_titles"
+          name="treat_underscore_as_space_for_titles"
+          value="True">
+        <label for="treat_underscore_as_space_for_titles">Treat underscore as space for titles.</label>
+        <div class="mt-5">
+            Enable this to replace underscores (_) with spaces in page titles, breadcrumbs, and page index. For example, "Page_With_Underscores" will be displayed as "Page With Underscores".
+        </div>
+      </div>
+    </div>
+{##}
+    <div class="form-group">
+      <div class="custom-checkbox">
         <input {%if config.GIT_WEB_SERVER %}checked=checked{% endif %} type="checkbox" id="git_web_server" name="git_web_server" value="True">
         <label for="git_web_server">Enable Git Web server <span class="text-secondary-dm bg-secondary-lm">(Experimental Feature)</span>.</label>
         <div class="mt-5">

--- a/otterwiki/wiki.py
+++ b/otterwiki/wiki.py
@@ -36,6 +36,7 @@ from otterwiki.helper import (
     get_filename,
     get_ftoc,
     get_pagename,
+    get_pagename_for_title,
     get_pagename_prefixes,
     patchset2urlmap,
     toast,
@@ -366,10 +367,10 @@ class Page:
 
         if self.content is not None:
             header = get_header(self.content)
-            self.pagename = get_pagename(
+            self.pagename = get_pagename_for_title(
                 self.pagepath, full=False, header=header
             )
-            self.pagename_full = get_pagename(
+            self.pagename_full = get_pagename_for_title(
                 self.pagepath, full=True, header=header
             )
 
@@ -478,7 +479,7 @@ class Page:
 
         if len(toc) > 0:
             # use first headline to overwrite pagename
-            self.pagename = get_pagename(
+            self.pagename = get_pagename_for_title(
                 self.pagename,
                 full=False,
                 header=toc[0][3],
@@ -548,7 +549,7 @@ class Page:
         # update pagename from toc
         if len(toc) > 0:
             # use first headline to overwrite pagename
-            self.pagename = get_pagename(
+            self.pagename = get_pagename_for_title(
                 self.pagename,
                 full=False,
                 header=toc[0][3],

--- a/tests/test_otterwiki.py
+++ b/tests/test_otterwiki.py
@@ -505,10 +505,22 @@ def test_move_page(test_client):
     )
     assert rv.status_code == 200
 
-    assert (
-        f'<a href="/{new_pagename}">{_new_file_name}</a>'.lower()
-        in rv.data.decode().lower()
-    )
+    response_text = rv.data.decode().lower()
+    if test_client.application.config.get(
+        "TREAT_UNDERSCORE_AS_SPACE_FOR_TITLES", False
+    ):
+        # when underscore replacement is enabled, expect spaces in display text
+        expected_display_name = _new_file_name.replace("_", " ")
+        assert (
+            f'<a href="/{new_pagename}">{expected_display_name}</a>'.lower()
+            in response_text
+        )
+    else:
+        # when underscore replacement is disabled, expect original underscores
+        assert (
+            f'<a href="/{new_pagename}">{_new_file_name}</a>'.lower()
+            in response_text
+        )
 
 
 def test_nested_files(test_client):


### PR DESCRIPTION
Not sure if you'd like this idea, but please tell me what you think.

Right now otterwiki has no distinction between page name and page title, but this could be useful if you want to have clean URLs and page names with spaces. So I've added a setting to treat underscores as spaces in various menus. This would allow us to have urls such as `/My_Page`, while seeing human-readable `My Page` in the menu. This is basically what MediaWiki does.