### PR TITLE
Small fixes

### DIFF
--- a/otterwiki/templates/editor.html
+++ b/otterwiki/templates/editor.html
@@ -351,7 +351,7 @@
                           <label for="attachment-thumbnail">as link with thumbnail</label>
                         </div>
                         <div class="mt-5 ml-10" id="thumbnail-size-container" style="display: none;">
-                          <input type="text" id="thumbnail-size" class="form-control" placeholder="max size in px">
+                          <input type="text" id="thumbnail-size" class="form-control" placeholder="max size in px" pattern="[0-9]*" inputmode="numeric" oninput="this.value = this.value.replace(/[^0-9]/g, '')">
                         </div>
                         <div class="custom-checkbox mt-5 ml-5">
                           <input type="checkbox" id="attachment-absolute" value="checked">

--- a/otterwiki/wiki.py
+++ b/otterwiki/wiki.py
@@ -890,7 +890,7 @@ class Page:
             "rename.html",
             title="Rename {}".format(self.pagename),
             pagepath=self.pagepath,
-            pagename=self.pagename_full,
+            pagename=get_pagename(self.pagepath, full=True),
             new_pagename=new_pagename,
             message=message,
             menutree=menutree.query(),


### PR DESCRIPTION
Fixes for my previous PRs (sorry):

1. Do not apply underscore replacement for page rename form. Currently when you try to rename a page called `Test_1/Test_2` with `TREAT_UNDERSCORE_AS_SPACE_FOR_TITLES=True`, current path is being displayed as `Test 1/Test 2`, which is incorrect.

2. For thumbnail size field, it's currently possible to write anything that is not a number (attempted in #317), so as a quick fix it's now only possible to input positive numbers.