### PR TITLE
More plugin hooks for html injection & processing

### DIFF
--- a/docs/plugin_examples/plugin_htmlinjection/otterwiki_htmlinjection.py
+++ b/docs/plugin_examples/plugin_htmlinjection/otterwiki_htmlinjection.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+"""
+HTML Injection Example Plugin for An Otter Wiki
+
+This is an example plugin that demonstrates the new HTML injection, link processing, image processing, and heading processing hooks.
+
+Features:
+- Injects HTML into the head and body sections
+- Adds a CSS class 'exampleClass' to all links
+- Sets alt attribute to 'example alt' for all images
+- Adds a CSS class 'exampleHeading' to all headings
+
+This plugin demonstrates:
+1. template_html_head_inject - Inject content into <head>
+2. template_html_body_inject - Inject content into <body>
+3. renderer_process_link - Process links during markdown rendering
+4. renderer_process_image - Process images during markdown rendering
+5. renderer_process_heading - Process headings during markdown rendering
+"""
+
+from bs4 import BeautifulSoup
+from otterwiki.plugins import hookimpl, plugin_manager
+
+
+class HtmlInjectionExample:
+    """
+    Example plugin demonstrating HTML injection and renderer processing hooks.
+    """
+
+    @hookimpl
+    def setup(self, app, db, storage):
+        """Initialize the plugin with the core objects."""
+        self.app = app
+        self.db = db
+        self.storage = storage
+
+    @hookimpl
+    def template_html_head_inject(self, page=None):
+        """
+        Inject HTML content into the head section.
+        In this example let's add some styling for example classes.
+        """
+        return '''
+    <!-- HTML Injection Example Plugin - Head Content -->
+    <style>
+        .exampleClass {
+            border-bottom: 1px dotted #007bff;
+            text-decoration: none;
+        }
+        .exampleClass:hover {
+            border-bottom-style: solid;
+        }
+        .exampleHeading {
+            border-left: 4px solid #007bff;
+            padding-left: 10px;
+            margin-left: -14px;
+        }
+    </style>
+'''
+
+    @hookimpl
+    def template_html_body_inject(self, page=None):
+        """
+        Inject HTML content into the body section.
+        """
+        return '<!-- HTML Injection Example Plugin - Body Content -->'
+
+    @hookimpl
+    def renderer_process_link(
+        self, link_html, link_url, link_text, link_title, page=None
+    ):
+        """
+        Adds `exampleClass` to classes for links during markdown rendering.
+        """
+        soup = BeautifulSoup(link_html, 'html.parser')
+        link_tag = soup.find('a')
+
+        if link_tag:
+            existing_classes = link_tag.get('class', [])
+            if isinstance(existing_classes, str):
+                existing_classes = existing_classes.split()
+
+            # Add 'exampleClass' if not already present
+            if 'exampleClass' not in existing_classes:
+                existing_classes.append('exampleClass')
+                link_tag['class'] = existing_classes
+
+        return str(soup)
+
+    @hookimpl
+    def renderer_process_image(
+        self, image_html, image_src, image_alt, image_title, page=None
+    ):
+        """
+        Sets fixed `alt` for images during markdown rendering.
+        """
+        soup = BeautifulSoup(image_html, 'html.parser')
+        img_tag = soup.find('img')
+
+        if img_tag:
+            # Set the alt attribute to 'example alt'
+            img_tag['alt'] = 'example alt'
+
+        return str(soup)
+
+    @hookimpl
+    def renderer_process_heading(
+        self,
+        heading_html,
+        heading_text,
+        heading_level,
+        heading_anchor,
+        page=None,
+    ):
+        """
+        Process headings during markdown rendering.
+        """
+        soup = BeautifulSoup(heading_html, 'html.parser')
+        heading_tag = soup.find(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])
+
+        if heading_tag:
+            existing_classes = heading_tag.get('class', [])
+            if isinstance(existing_classes, str):
+                existing_classes = existing_classes.split()
+
+            # Add 'exampleHeading' if not already present
+            if 'exampleHeading' not in existing_classes:
+                existing_classes.append('exampleHeading')
+                heading_tag['class'] = existing_classes
+
+        return str(soup)
+
+
+plugin_manager.register(HtmlInjectionExample())

--- a/docs/plugin_examples/plugin_htmlinjection/pyproject.toml
+++ b/docs/plugin_examples/plugin_htmlinjection/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "otterwiki_htmlinjection"
+description = "Example plugin demonstrating HTML injection and renderer processing hooks."
+version = "0.1.0"
+authors = [
+    { name = "deseven", email = "git@d7.wtf" }
+]
+dependencies = [
+    "beautifulsoup4"
+]
+
+[project.entry-points.otterwiki]
+htmlinjection = "otterwiki_htmlinjection"

--- a/otterwiki/plugins.py
+++ b/otterwiki/plugins.py
@@ -51,6 +51,52 @@ class OtterWikiPluginSpec:
         This hooks receives a html string containing the page content.
         """
 
+    @hookspec
+    def template_html_head_inject(self, page=None) -> str | None:
+        """
+        This hook allows plugins to inject HTML content into the <head> section
+        of the page template. The content will be added after the default CSS/JS.
+        """
+
+    @hookspec
+    def template_html_body_inject(self, page=None) -> str | None:
+        """
+        This hook allows plugins to inject HTML content at the end of the <body>
+        section of the page template, before the closing </body> tag.
+        """
+
+    @hookspec
+    def renderer_process_link(
+        self, link_html, link_url, link_text, link_title, page=None
+    ) -> str | None:
+        """
+        This hook allows plugins to process and modify individual links during rendering.
+        It's called for each link as it's being rendered from markdown.
+        """
+
+    @hookspec
+    def renderer_process_image(
+        self, image_html, image_src, image_alt, image_title, page=None
+    ) -> str | None:
+        """
+        This hook allows plugins to process and modify individual images during rendering.
+        It's called for each image as it's being rendered from markdown.
+        """
+
+    @hookspec
+    def renderer_process_heading(
+        self,
+        heading_html,
+        heading_text,
+        heading_level,
+        heading_anchor,
+        page=None,
+    ) -> str | None:
+        """
+        This hook allows plugins to process and modify individual headings during rendering.
+        It's called for each heading as it's being rendered from markdown.
+        """
+
 
 # pluggy doesn't by default handle chaining the output of one plugin into
 # another, so this is a small utility function to do this.

--- a/otterwiki/server.py
+++ b/otterwiki/server.py
@@ -271,7 +271,24 @@ app.jinja_env.globals.update(os_getenv=os.getenv)
 
 from otterwiki.helper import load_custom_html
 
-app.jinja_env.globals.update(load_custom_html=load_custom_html)
+
+def plugin_html_head_inject(page=None):
+    """Template function to inject HTML into the head section via plugins."""
+    results = plugin_manager.hook.template_html_head_inject(page=page)
+    return ''.join(result for result in results if result)
+
+
+def plugin_html_body_inject(page=None):
+    """Template function to inject HTML into the body section via plugins."""
+    results = plugin_manager.hook.template_html_body_inject(page=page)
+    return ''.join(result for result in results if result)
+
+
+app.jinja_env.globals.update(
+    load_custom_html=load_custom_html,
+    plugin_html_head_inject=plugin_html_head_inject,
+    plugin_html_body_inject=plugin_html_body_inject,
+)
 
 # initialize git via http
 import otterwiki.remote

--- a/otterwiki/templates/layout.html
+++ b/otterwiki/templates/layout.html
@@ -67,6 +67,8 @@
     {{config.HTML_EXTRA_HEAD|safe}}
     <!-- Custom HTML head content from file -->
     {{load_custom_html('customHead.html')|safe}}
+    <!-- Plugin HTML head content -->
+    {{plugin_html_head_inject()|safe}}
 {%- block head %}
 {% endblock -%}
 {%- if request.cookies.get('halfmoon_preferredMode') == "dark-mode" %}
@@ -273,5 +275,7 @@
   {{config.HTML_EXTRA_BODY|safe}}
   <!-- Custom HTML body content from file -->
   {{load_custom_html('customBody.html')|safe}}
+  <!-- Plugin HTML body content -->
+  {{plugin_html_body_inject()|safe}}
 </body>
 </html>


### PR DESCRIPTION
Currently you only have a way to grab the whole rendered page in html, which could be problematic if you need to alter specific elements (in that case you end up with either using regexes or parsing the whole html to do what you want - not ideal).

There is also no way to inject additional resources or scripts into the page, which I believe a plugin should be able to do.

So this PR adds 5 additional hooks:
1. `template_html_head_inject` - Inject content into `<head>`
2. `template_html_body_inject` - Inject content into `<body>`
3. `renderer_process_link` - Process links during markdown rendering
4. `renderer_process_image` - Process images during markdown rendering
5. `renderer_process_heading` - Process headings during markdown rendering

Obviously more could be added, [the list is quite large](https://mistune.lepture.com/en/latest/renderers.html#available-methods), but I think this would do for now.

Any thoughts?