### PR TITLE
feature: link paste using page title as link text

### DIFF
--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -1137,7 +1137,7 @@ var otterwiki_editor = {
             otterwiki_editor.img('['+filename+']('+url+')\n');
         }
     },
-    insert_wikilink: function() {
+    insert_wikilink: function(absolute = true) {
         if (!cm_editor) { return; }
         let state = otterwiki_editor._getState();
         // we don't mess with existing tokens of these kinds
@@ -1157,7 +1157,13 @@ var otterwiki_editor = {
             cm_editor.setSelection(word.anchor, word.head);
         }
         if (cm_editor.getSelection().trim().length == 0) {
-            cm_editor.replaceSelection('[['+page+']]\n');
+            if(!absolute) {
+                // from issue #357 allow for link insert with [[ title | page ]] format
+                let title = page.split('/').at(-1);
+                cm_editor.replaceSelection('[[' + title + '|' + page + ']]\n');
+            } else {
+                cm_editor.replaceSelection('[[' + page + ']]\n');
+            }
         } else {
             let text = cm_editor.getSelection();
             cm_editor.replaceSelection('[['+text+'|'+page+']]\n');

--- a/otterwiki/templates/editor.html
+++ b/otterwiki/templates/editor.html
@@ -373,6 +373,7 @@
 {% endfor %}
                         </select>
                         <button class="btn mt-5" type="button" onclick="otterwiki_editor.insert_wikilink()" title="Copy into the editor" ><i class="fas fa-paste"></i></button>
+                        <button class="btn mt-5" type="button" onclick="otterwiki_editor.insert_wikilink(false)" title="Copy into the editor, use page name as link text" ><i class="fa fa-heading"></i></button>
                     </form>
                     </div>
 {{ super() }}


### PR DESCRIPTION
Implemented a feature from #357

I added a second button to the Wikilink section of the editor.  This will allow for a wikilink to be added to the editor with the page title used as the link text.

With minimal edits to `insert_wikilink()` I was able to make the function work for both the existing insert and the new functionality.

Wasn't sure about the targeted javascript version, happy to take any feedback on the implementation, not a python dev, so I was pretty happy to just get the dev environment running.