### PR TITLE
Fix lowercase GitHub-style alerts

### DIFF
--- a/otterwiki/renderer_plugins.py
+++ b/otterwiki/renderer_plugins.py
@@ -524,7 +524,8 @@ class mistunePluginAlerts:
     }
     TYPES_WITH_PIPES = "|".join(TYPE_ICONS.keys())
     ALERT_LEADING = re.compile(
-        r'^ *\>(\s*\[!(' + TYPES_WITH_PIPES + r')\])?', flags=re.MULTILINE
+        r'^ *\>(\s*\[!(' + TYPES_WITH_PIPES + r')\])?',
+        flags=re.MULTILINE + re.I,
     )
     ALERT_BLOCK = re.compile(
         r'(?: {0,3}>\s*\[!('

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -524,11 +524,17 @@ def test_fold():
 def test_all_alert_types():
     from otterwiki.renderer_plugins import mistunePluginAlerts
 
-    for type, icon in mistunePluginAlerts.TYPE_ICONS.items():
+    def alert_tests():
+        for type, icon in mistunePluginAlerts.TYPE_ICONS.items():
+            yield type, icon
+            yield type.lower(), icon
+
+    for type, icon in alert_tests():
         md = f"> [!{type}]\n>text\n>text\n"
         html, _, _ = render.markdown(md)
         assert 'text\ntext' in html
         assert icon in html
+        assert f"[!{type}]" not in html
 
 
 def test_alerts():


### PR DESCRIPTION
GitHub-style alerts in Markdown are case-insensitive. For example, an inline warning in the style of

```markdown
> [!warning]
> Body of the warning
```

GitHub rendering:
> [!warning]
> Body of the warning

is supported on GitHub. While Otterwiki detects this as a warning, the `[!warning]` command is not removed from the rendering of the box, because one regex was not case-insensitive.

Current Otterwiki rendering:

<img width="283" height="84" alt="Incorrect rendering of [!warning]" src="https://github.com/user-attachments/assets/4b7ac98e-8ad5-41c2-b1d2-13ee6f5eec06" />

This PR fixes this bug and adds a test that checks whether the command was removed from the rendering.