### PR TITLE
Small visual tweaks to '▹' and '□' icon alignment in sidebar

### DIFF
--- a/otterwiki/static/css/partials/sidebar.css
+++ b/otterwiki/static/css/partials/sidebar.css
@@ -164,7 +164,6 @@ a.sidebar-toc-6 { padding-left: calc(7 * var(--spacing) - var(--radius) - 13px);
     width: 1.3rem;
     display: inline-block;
     content: '▹ ';
-    vertical-align: text-top;
 }
 
 .sidebarmenu details[open] > summary::before {
@@ -179,6 +178,8 @@ a.sidebar-toc-6 { padding-left: calc(7 * var(--spacing) - var(--radius) - 13px);
     content: '□ ';
     font-size: 0.5rem;
     vertical-align: middle;
+    position: relative;
+    bottom: 0.1rem;
 }
 
 .sidebar-menu li {


### PR DESCRIPTION
Thanks for An Otter Wiki, it's fantastic!

This very small PR tweaks the vertical alignment of the '▹' and '□' icons in the sidebar. The triangle appears _slightly_ too high, and the square slightly too low.

Before/after screenshot attached.

Thank you!

![otterwiki-sidebar-micro-alignment-tweaks](https://github.com/user-attachments/assets/b379941a-c98a-4fb6-9a5a-c6027525362d)