### PR TITLE
Plugin hook for WikiLinks rendering and example plugin

### DIFF
--- a/docs/plugin_examples/plugin_redlinks/otterwiki_redlinks.py
+++ b/docs/plugin_examples/plugin_redlinks/otterwiki_redlinks.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+"""
+This is an example plugin for An Otter Wiki that demonstrates the
+renderer_process_wikilink hook.
+
+The RedLinks plugin checks if a WikiLink points to an existing page and
+marks non-existent pages with a red color, similar to MediaWiki's behavior.
+
+This plugin uses the setup() hook to get access to the storage object,
+and the renderer_process_wikilink() hook to modify WikiLink rendering.
+"""
+
+import urllib.parse
+from otterwiki.plugins import hookimpl, plugin_manager
+
+
+class RedLinks:
+    @hookimpl
+    def setup(self, app, db, storage) -> None:
+        """Initialize the plugin with access to core objects."""
+        self.storage = storage
+
+    @hookimpl
+    def renderer_process_wikilink(
+        self, wikilink_html, wikilink_url, wikilink_text, page=None
+    ):
+        """
+        Process WikiLinks and mark non-existent pages with red color.
+
+        Args:
+            wikilink_html: The generated HTML for the wikilink
+            wikilink_url: The URL the wikilink points to (e.g., "/Page%20Name")
+            wikilink_text: The display text of the wikilink
+            page: The current page object (optional)
+
+        Returns:
+            Modified HTML with red styling for non-existent pages
+        """
+        # Parse the URL to get the page path
+        parsed_url = urllib.parse.urlparse(wikilink_url)
+        page_path = urllib.parse.unquote(parsed_url.path)
+        page_path = page_path.strip('/')
+        if not page_path:
+            return wikilink_html
+
+        # Check both with and without .md extension for directories
+        page_file = (
+            page_path if page_path.endswith('.md') else f"{page_path}.md"
+        )
+
+        # Check if the page exists in storage (as .md file or as directory)
+        page_exists = self.storage.exists(page_file) or self.storage.isdir(
+            page_path
+        )
+
+        # If page doesn't exist, add red styling
+        if not page_exists:
+            # Add a class and inline style for red links
+            wikilink_html = wikilink_html.replace(
+                '<a href=',
+                '<a class="redlink" style="color: #d33; text-decoration: none; border-bottom: 1px dotted #d33;" href=',
+            )
+
+        return wikilink_html
+
+
+plugin_manager.register(RedLinks())

--- a/docs/plugin_examples/plugin_redlinks/pyproject.toml
+++ b/docs/plugin_examples/plugin_redlinks/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "otterwiki_redlinks"
+description = "An example plugin for An Otter Wiki that marks WikiLinks to non-existent pages in red, similar to MediaWiki's redlinks feature."
+version = "0.1.0"
+authors = [
+    { name = "deseven", email = "git@d7.wtf" }
+]
+
+[project.entry-points.otterwiki]
+redlinks = "otterwiki_redlinks"

--- a/otterwiki/plugins.py
+++ b/otterwiki/plugins.py
@@ -97,6 +97,16 @@ class OtterWikiPluginSpec:
         It's called for each heading as it's being rendered from markdown.
         """
 
+    @hookspec
+    def renderer_process_wikilink(
+        self, wikilink_html, wikilink_url, wikilink_text, page=None
+    ) -> str | None:
+        """
+        This hook allows plugins to process and modify individual wikilinks during rendering.
+        It's called for each wikilink as it's being rendered from markdown.
+        WikiLinks are defined in the format [[Page Name]] or [[Page Name|Display Text]].
+        """
+
 
 # pluggy doesn't by default handle chaining the output of one plugin into
 # another, so this is a small utility function to do this.


### PR DESCRIPTION
Adds a new hook for WikiLinks and a plugin that marks non-existing pages with red (MediaWiki style).