### PR TITLE
Fixed broken syntax page

### DIFF
--- a/otterwiki/views.py
+++ b/otterwiki/views.py
@@ -116,6 +116,7 @@ def syntax():
     return render_template(
         "syntax.html",
         in_help=True,
+        pagepath="",
     )
 
 


### PR DESCRIPTION
The `/-/syntax` page cannot be loaded after changes introduced in f4af9a8.

The `pagepath` was undefined even before in that case, but using `lower()` on it was returning an empty string, so this wasn't a problem. Now it is :)