### PR TITLE
Inline attachment improvements

### DIFF
--- a/otterwiki/templates/editor.html
+++ b/otterwiki/templates/editor.html
@@ -479,12 +479,67 @@
     bottom_panel.style.display = 'block';
     cm_editor.addPanel(bottom_panel, {position: "bottom", stable: true});
 
+    function refreshAttachmentsDropdown(attachments, selectFilename) {
+        var attachmentSelect = document.getElementById('attachment-filename');
+        if (!attachmentSelect) return;
+
+        // Clear existing options except the first (placeholder)
+        while (attachmentSelect.options.length > 1) {
+            attachmentSelect.remove(1);
+        }
+
+        // Add all attachments
+        if (attachments && attachments.length > 0) {
+            attachments.forEach(function(file) {
+                var optionValue = file.filename + "/--/" + file.url + "/--/" + (file.thumbnail_url || '');
+                var option = document.createElement('option');
+                option.value = optionValue;
+                option.textContent = file.filename;
+                attachmentSelect.appendChild(option);
+
+                // Make last inserted attachment selected
+                if (selectFilename && file.filename === selectFilename) {
+                    attachmentSelect.value = optionValue;
+                }
+            });
+
+            // If an attachment was selected, update the preview and enable/disable controls
+            if (selectFilename) {
+                otterwiki_editor.update_attachment_preview();
+            }
+        }
+    }
+
 {#
 thx to https://github.com/sparksuite/simplemde-markdown-editor/issues/328#issuecomment-227075500
 #}
     inlineAttachment.editors.codemirror4.attach(cm_editor, {
-        uploadUrl: "{{ url_for('inline_attachment', pagepath=pagepath) | urlquote }}",
-        urlText: "![]({filename})",
+        uploadUrl: {{ url_for('inline_attachment', pagepath=pagepath) | tojson }},
+        allowedTypes: ['*'],
+        urlText: function(filename, result) {
+            var imageExtensions = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg', '.bmp', '.tiff'];
+            var isImage = false;
+
+            for (var i = 0; i < imageExtensions.length; i++) {
+                if (filename.toLowerCase().endsWith(imageExtensions[i])) {
+                    isImage = true;
+                    break;
+                }
+            }
+
+            var displayName = filename.replace(/^\.\//, '');
+
+            if (isImage) {
+                return "![" + displayName + "](" + filename + ")";
+            } else {
+                return "[" + displayName + "](" + filename + ")";
+            }
+        },
+        onFilenamePrompt: function(suggestedFilename, file) {
+            // Prompt user to confirm or change the filename
+            var userFilename = prompt("Enter filename for the attachment:", suggestedFilename);
+            return userFilename;
+        },
         onFileUploadResponse: function(xhr) {
             var result = JSON.parse(xhr.responseText),
             filename = result[this.settings.jsonFieldName];
@@ -499,6 +554,12 @@ thx to https://github.com/sparksuite/simplemde-markdown-editor/issues/328#issuec
                 var text = this.editor.getValue().replace(this.lastValue, newValue);
                 this.editor.setValue(text);
                 this.settings.onFileUploaded.call(this, filename);
+
+                // Refresh dropdown with attachments from response and select the uploaded file
+                var uploadedFilename = filename.replace(/^\.\//, '');
+                if (result.attachments) {
+                    refreshAttachmentsDropdown(result.attachments, uploadedFilename);
+                }
             }
             return false;
         }
@@ -536,7 +597,7 @@ thx to https://github.com/sparksuite/simplemde-markdown-editor/issues/328#issuec
         formData.append("cursor_line", cm_editor.getCursor().line);
         formData.append("cursor_ch", cm_editor.getCursor().ch);
         formData.append("revision", "{{revision}}");
-        fetch("{{ url_for('draft', path=pagepath) | urlquote }}", {
+        fetch({{ url_for('draft', path=pagepath) | tojson }}, {
             method: 'POST',
             body: formData,
         })
@@ -598,7 +659,7 @@ thx to https://github.com/sparksuite/simplemde-markdown-editor/issues/328#issuec
         formData.append("cursor_ch", cm_editor.getCursor().ch);
 
         /* FIXME: display loader */
-        fetch("{{ url_for('preview', path=pagepath) | urlquote }}", {
+        fetch({{ url_for('preview', path=pagepath) | tojson }}, {
                 method: 'POST',
                 body: formData,
             })

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -3,6 +3,7 @@
 
 import re
 import bs4
+import json
 from urllib.parse import unquote
 
 
@@ -27,20 +28,31 @@ def test_urlquote(test_client):
             js = javascript.text
             if "uploadUrl" not in js:
                 continue
-            # check uploadUrl
-            m = re.search(r"uploadUrl: \"/([^\"]+)/inline_attachment\",", js)
-            assert m
+            # check uploadUrl - now using tojson filter which produces JSON strings
+            m = re.search(r'uploadUrl: ("(?:[^"\\]|\\.)*"),', js)
+            assert m, f"Could not find uploadUrl in JavaScript for {pagename}"
             uploadUrl_found = True
-            # unquote to check if the url matches the pagename
-            uploadUrl = unquote(m.group(1))
-            assert uploadUrl == pagename
-            # check fetchUrl preview
-            m = re.search(r"fetch\(\"/([^\"]+)/preview\",", js)
-            assert m
+            # parse the JSON string and unquote to check if the url matches the pagename
+            uploadUrl_json = json.loads(m.group(1))
+            uploadUrl_path = uploadUrl_json.rsplit('/inline_attachment', 1)[0]
+            uploadUrl = unquote(uploadUrl_path.lstrip('/'))
+            assert (
+                uploadUrl == pagename
+            ), f"uploadUrl mismatch: {uploadUrl} != {pagename}"
+
+            # check fetchUrl preview - also using tojson filter
+            m = re.search(r'fetch\(("(?:[^"\\]|\\.)*"),', js)
+            assert m, f"Could not find fetch URL in JavaScript for {pagename}"
             fetchUrl_found = True
-            # unquote to check if the url matches the pagename
-            fetchUrl = unquote(m.group(1))
-            assert fetchUrl == pagename
+            # parse the JSON string and unquote to check if the url matches the pagename
+            fetchUrl_json = json.loads(m.group(1))
+            fetchUrl_path = fetchUrl_json.rsplit('/preview', 1)[0].rsplit(
+                '/draft', 1
+            )[0]
+            fetchUrl = unquote(fetchUrl_path.lstrip('/'))
+            assert (
+                fetchUrl == pagename
+            ), f"fetchUrl mismatch: {fetchUrl} != {pagename}"
 
         # make sure the right block has been found and checked
         assert uploadUrl_found


### PR DESCRIPTION
This PR adds the following improvements to inline attachments:
1. All file types are now accepted as inline attachments with correct file name and type handling.
2. Users are prompted to confirm or change the file name on each upload and can cancel if needed.
3. The attachment list in the editor sidebar updates automatically.

It also fixes a bug where inline attachments were saved to an incorrect directory when the page name contained `&`.