### PR TITLE
feat(docker): add label requried for renovate to detect the changelog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 #
 FROM debian:12.11-slim AS compile-stage
 LABEL maintainer="Ralph Thesen <mail@redimp.de>"
+LABEL org.opencontainers.image.source="https://github.com/redimp/otterwiki"
 # install python environment
 RUN --mount=target=/var/cache/apt,type=cache,sharing=locked \
     rm /etc/apt/apt.conf.d/docker-clean && \

--- a/docker/Dockerfile.slim
+++ b/docker/Dockerfile.slim
@@ -3,6 +3,7 @@
 #
 FROM alpine:3.20.1 AS compile-stage
 LABEL maintainer="Ralph Thesen <mail@redimp.de>"
+LABEL org.opencontainers.image.source="https://github.com/redimp/otterwiki"
 # install build environment (mostly necessary to build Pillow on armv6/7)
 RUN apk add python3 python3-dev py3-virtualenv \
             zlib-dev jpeg-dev gcc musl-dev libxml2-dev libxslt-dev


### PR DESCRIPTION
At the moment when [Renovate](https://docs.renovatebot.com/) (tool for updating dependencies) doesn't know where to look for otterwiki changelog.

With this change, it will be able to fetch them from the release page, as described [here](https://docs.renovatebot.com/modules/datasource/docker/#description).

Example of the PR before this change:
<img width="1217" height="725" alt="image" src="https://github.com/user-attachments/assets/b9c6ab67-e949-4e63-988b-ab6b279e232e" />

Example of the PR with image that has this label:
<img width="1232" height="829" alt="image" src="https://github.com/user-attachments/assets/1f19d44a-7b15-41cc-9c6b-5ba7e614d71b" />

Also thanks for creating such nice software :D


