### PR TITLE
Current page highlight on sidebar

### DIFF
--- a/otterwiki/static/css/partials/sidebar.css
+++ b/otterwiki/static/css/partials/sidebar.css
@@ -210,6 +210,10 @@ a.sidebar-toc-6 { padding-left: calc(7 * var(--spacing) - var(--radius) - 13px);
     color: rgba(255, 255, 255, 1);
 }
 
+.dark-mode .sidebarmenu span {
+    color: var(--dm-link-text-color);
+}
+
 .sidebar-link {
     padding-left: 1rem;
 }

--- a/otterwiki/templates/snippets/menutree.html
+++ b/otterwiki/templates/snippets/menutree.html
@@ -15,7 +15,11 @@
             <li>
                 <details {% if pagepath and pagepath.lower().startswith(value.path.lower()) %}open{% endif %}>
                     <summary class="sidebarmenu">
+                        {% if pagepath and pagepath.lower() == value.path.lower() %}
+                        <span>{{value["header"]}}</span>
+                        {% else %}
                         <a href="/{{value["path"]}}">{{value["header"]}}</a>
+                        {% endif %}
                     </summary>
                     <ul class="sidebarmenu sidebarmenu-loop-{{ loop.depth % 4 }}">{{ loop(value["children"].items())}}
                     </ul>
@@ -24,7 +28,11 @@
             {%- else %}
                 <li>
                     <div class="summary-details">
+                        {% if pagepath and pagepath.lower() == value.path.lower() %}
+                        <span>{{value["header"]}}</span>
+                        {% else %}
                         <a href="/{{value["path"]}}">{{value["header"]}}</a>
+                        {% endif %}
                     </div>
                 </li>
             {%endif%}


### PR DESCRIPTION
This is a feature to highlight the current page on the sidebarmenu.  This will change the render of the current page from an `<a>` tag to a `<span>` tag.

When there are many pages on the same level having the highlight on the sidebarmenu is helpful. I could not think of any reason to keep the link on the sidebarmenu clickable and navigable when on the page itself.

I reused the theme color from the top breadcrumb render.  The full path is used to determine what to highlight so there should be no issues with overlaping names of pages.

This is the render of a top level page with no children
<img width="237" height="173" alt="image" src="https://github.com/user-attachments/assets/35958b09-2866-4364-98b0-7af547f68b36" />

This is the render of a parent page
<img width="307" height="363" alt="image" src="https://github.com/user-attachments/assets/2a1c0998-dd58-4f30-ba2e-8676f66deb54" />

This is the render of a child page
<img width="258" height="203" alt="image" src="https://github.com/user-attachments/assets/2a05ffaf-4749-49d0-8a56-93e8369c002b" />

Open to any feedback.
