### PR TITLE
Added a light mode sidebar css rule.

### DIFF
--- a/otterwiki/static/css/partials/sidebar.css
+++ b/otterwiki/static/css/partials/sidebar.css
@@ -203,6 +203,10 @@ a.sidebar-toc-6 { padding-left: calc(7 * var(--spacing) - var(--radius) - 13px);
     border-color: transparent;
 }
 
+.sidebarmenu span {
+    color: var(--lm-link-text-color);
+}
+
 .dark-mode .sidebarmenu a {
     color: var(--dm-sidebar-link-text-color-hover);
 }


### PR DESCRIPTION
Reported in #393 there was a missing css rule for the `span` render in light mode to highlight the current page highlight.
Added a missed css rule for highlighting the new `span` render for the current page on the sidebar

Render in light mode
<img width="366" height="195" alt="image" src="https://github.com/user-attachments/assets/14081c95-29ab-40a7-974c-53153a8548db" />

This addition did not effect the dark mode render
<img width="349" height="151" alt="image" src="https://github.com/user-attachments/assets/5de78607-b65f-440a-8abb-3da68ecc5691" />
