### PR TITLE
Adjust font size for form control in CSS

### DIFF
--- a/otterwiki/static/css/otterwiki.css
+++ b/otterwiki/static/css/otterwiki.css
@@ -536,3 +536,8 @@ mark {
 .subsection-table {
     padding-left: 1rem;
 }
+
+.form-control {
+    /* override halfmoon's form control font size to prevent mobile zoom */
+    font-size: 16px;
+}


### PR DESCRIPTION
On ios clicking form fields zooms in. This pr override halfmoon's form control font size to prevent mobile zoom.