### PR TITLE
feat: Introduce ADMIN_USER_EMAIL setting for controlled admin registration

### DIFF
--- a/otterwiki/auth.py
+++ b/otterwiki/auth.py
@@ -238,13 +238,23 @@ class SimpleAuth:
         is_admin = False
         # handle auto approval
         is_approved = app.config["AUTO_APPROVAL"] is True
+        # check if user registered with ADMIN_USER_EMAIL
         if not empty(app.config["ADMIN_USER_EMAIL"]):
             if (
                 len(self.User.query.filter_by(is_admin=True).all()) < 1
                 and email == app.config["ADMIN_USER_EMAIL"]
             ):
+                # user is expected to be admin
                 is_admin = True
                 is_approved = True
+
+            if (
+                len(self.User.query.filter_by(is_admin=True).all()) > 0
+                and email == app.config["ADMIN_USER_EMAIL"]
+            ):
+                app.logger.warning(
+                    f"Admin registration with {email}==ADMIN_USER_EMAIL skipped: Existing admin account(s) found."
+                )
         # if not limit is set by ADMIN_USER_EMAIL first user is admin
         elif len(self.User.query.all()) < 1:
             is_admin = True

--- a/otterwiki/auth.py
+++ b/otterwiki/auth.py
@@ -235,14 +235,20 @@ class SimpleAuth:
         # hash password
         hashed_password = generate_password_hash(password, method="scrypt")
         # handle flags
-        # first user is admin
-        if len(self.User.query.all()) < 1:
+        is_admin = False
+        # handle auto approval
+        is_approved = app.config["AUTO_APPROVAL"] is True
+        if not empty(app.config["ADMIN_USER_EMAIL"]):
+            if (
+                len(self.User.query.filter_by(is_admin=True).all()) < 1
+                and email == app.config["ADMIN_USER_EMAIL"]
+            ):
+                is_admin = True
+                is_approved = True
+        # if not limit is set by ADMIN_USER_EMAIL first user is admin
+        elif len(self.User.query.all()) < 1:
             is_admin = True
             is_approved = True
-        else:
-            is_admin = False
-            # handle auto approval
-            is_approved = app.config["AUTO_APPROVAL"] is True
         # create user object
         user = self.User(  # pyright: ignore
             name=name,

--- a/otterwiki/server.py
+++ b/otterwiki/server.py
@@ -72,6 +72,7 @@ app.config.update(
     TREAT_UNDERSCORE_AS_SPACE_FOR_TITLES=False,
     HOME_PAGE="",
     RENDERER_HTML_WHITELIST="",
+    ADMIN_USER_EMAIL="",
 )
 app.config.from_envvar("OTTERWIKI_SETTINGS", silent=True)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -834,3 +834,164 @@ def test_user_with_empty_password_issues_204_205(app_with_user, test_client):
             follow_redirects=True,
         )
         assert "please update your password." in rv.data.decode()
+
+
+def test_register_first_user(create_app, test_client, req_ctx):
+    """
+    This test verifies that the first user that is registered becomes admin.
+    """
+    from otterwiki.auth import SimpleAuth, db
+
+    first_email = "admin@example.com"
+    second_email = "random@example.com"
+    password = "password1234"
+
+    db.session.query(SimpleAuth.User).delete()
+    # check users to make sure we start from scratch
+    assert len(SimpleAuth.User.query.all()) == 0
+    create_app.config["ADMIN_USER_EMAIL"] = ""
+
+    # Register random_email
+    rv = test_client.post(
+        "/-/register",
+        data={
+            "email": first_email,
+            "name": "Admin User",
+            "password1": password,
+            "password2": password,
+        },
+        follow_redirects=True,
+    )
+    assert rv.status_code == 200
+    # Register admin email
+    rv = test_client.post(
+        "/-/register",
+        data={
+            "email": second_email,
+            "name": "Random User",
+            "password1": password,
+            "password2": password,
+        },
+        follow_redirects=True,
+    )
+    assert rv.status_code == 200
+
+    admin_user = SimpleAuth.User.query.filter_by(email=first_email).first()
+    assert admin_user
+    assert admin_user.is_admin is True
+    random_user = SimpleAuth.User.query.filter_by(email=second_email).first()
+    assert random_user
+    assert random_user.is_admin is False
+    # clean up
+    db.session.query(SimpleAuth.User).delete()
+    create_app.config["ADMIN_USER_EMAIL"] = ""
+
+
+def test_register_first_admin_user_email(create_app, test_client, req_ctx):
+    """
+    This test verifies that with ADMIN_USER_EMAIL configured only user with
+    this email gets admin permissions
+    """
+    from otterwiki.auth import SimpleAuth, db
+
+    admin_email = "admin@example.com"
+    random_email = "random@example.com"
+    password = "password1234"
+
+    db.session.query(SimpleAuth.User).delete()
+    # check users to make sure we start from scratch
+    assert len(SimpleAuth.User.query.all()) == 0
+    create_app.config["ADMIN_USER_EMAIL"] = admin_email
+
+    # Register random_email
+    rv = test_client.post(
+        "/-/register",
+        data={
+            "email": random_email,
+            "name": "Random User",
+            "password1": password,
+            "password2": password,
+        },
+        follow_redirects=True,
+    )
+    assert rv.status_code == 200
+    # Register admin email
+    rv = test_client.post(
+        "/-/register",
+        data={
+            "email": admin_email,
+            "name": "Admin User",
+            "password1": password,
+            "password2": password,
+        },
+        follow_redirects=True,
+    )
+    assert rv.status_code == 200
+
+    admin_user = SimpleAuth.User.query.filter_by(email=admin_email).first()
+    assert admin_user
+    assert admin_user.is_admin is True
+    random_user = SimpleAuth.User.query.filter_by(email=random_email).first()
+    assert random_user
+    assert random_user.is_admin is False
+    # clean up
+    db.session.query(SimpleAuth.User).delete()
+    create_app.config["ADMIN_USER_EMAIL"] = ""
+
+
+def test_register_first_admin_user_email_disabled(
+    create_app, test_client, req_ctx
+):
+    """
+    This test verifies that even with ADMIN_USER_EMAIL configured
+    a user with this email does not get admin acccess if another admin is already registered.
+    This prevents edge cases where old admin users have been deleted and the config is forgotten.
+    """
+    from otterwiki.auth import SimpleAuth, db
+
+    admin_email = "admin@example.com"
+    random_email = "random@example.com"
+    password = "password1234"
+
+    db.session.query(SimpleAuth.User).delete()
+    # check users to make sure we start from scratch
+    assert len(SimpleAuth.User.query.all()) == 0
+
+    create_app.config["ADMIN_USER_EMAIL"] = ""
+    # Register random_email
+    rv = test_client.post(
+        "/-/register",
+        data={
+            "email": random_email,
+            "name": "Random User",
+            "password1": password,
+            "password2": password,
+        },
+        follow_redirects=True,
+    )
+    assert rv.status_code == 200
+
+    # enable ADMIN_USER_EMAIL, must have no effect since random_email already is admin
+    create_app.config["ADMIN_USER_EMAIL"] = admin_email
+    # Register admin email
+    rv = test_client.post(
+        "/-/register",
+        data={
+            "email": admin_email,
+            "name": "Admin User",
+            "password1": password,
+            "password2": password,
+        },
+        follow_redirects=True,
+    )
+    assert rv.status_code == 200
+
+    admin_user = SimpleAuth.User.query.filter_by(email=admin_email).first()
+    assert admin_user
+    assert admin_user.is_admin is False
+    random_user = SimpleAuth.User.query.filter_by(email=random_email).first()
+    assert random_user
+    assert random_user.is_admin is True
+    # clean up
+    db.session.query(SimpleAuth.User).delete()
+    create_app.config["ADMIN_USER_EMAIL"] = ""


### PR DESCRIPTION
This PR introduces the `ADMIN_USER_EMAIL` configuration option. When set, only the user whose email matches this setting is granted administrator privileges. Additionally, the implenetatio ensures that no administrators who have been deleted can be re-registered while other administrator accounts exist.

This approach addresses the concerns discussed in #353.