### PR TITLE
Bug/Sidebar span line height fix

### DIFF
--- a/otterwiki/static/css/partials/sidebar.css
+++ b/otterwiki/static/css/partials/sidebar.css
@@ -186,7 +186,7 @@ a.sidebar-toc-6 { padding-left: calc(7 * var(--spacing) - var(--radius) - 13px);
     margin-bottom: .5rem;
 }
 
-.sidebar-menu a {
+.sidebar-menu a, .sidebar-menu span {
     line-height: 2rem;
 }
 


### PR DESCRIPTION
Added the missing CSS rule to make the line-height the same for `<a>` and `<span>` entries in the `sidebar-menu`.

Without this rule, the line height defaulted to the `.sidebarmenu li` rule, which sets the line-height to 1, which would resolve to the standard font size for the line-height.

I know it is hard to see in the images, but this was the render before the update
<img width="268" height="176" alt="original-span-spacing" src="https://github.com/user-attachments/assets/abd7714a-973c-4e16-b453-91256ee9ba48" />

This is the render after the update
<img width="272" height="187" alt="updated-span-spacing" src="https://github.com/user-attachments/assets/d1760d77-f799-4756-98c1-adff05ebfd07" />

It is only a 3-pixel difference on my screen, but the menu moving during navigation was not an ideal experience.  Sorry, it took 3 PRs to get this feature in correctly. 

related to #393 and #396 