### PR TITLE
fix(docker): add docker labels to production stage and not compile-stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@
 # compile stage
 #
 FROM debian:12.11-slim AS compile-stage
-LABEL maintainer="Ralph Thesen <mail@redimp.de>"
-LABEL org.opencontainers.image.source="https://github.com/redimp/otterwiki"
 # install python environment
 RUN --mount=target=/var/cache/apt,type=cache,sharing=locked \
     rm /etc/apt/apt.conf.d/docker-clean && \
@@ -50,6 +48,8 @@ CMD ["tox"]
 # production stage
 #
 FROM debian:12.11-slim
+LABEL maintainer="Ralph Thesen <mail@redimp.de>"
+LABEL org.opencontainers.image.source="https://github.com/redimp/otterwiki"
 # arg for marking dev images
 ARG GIT_TAG
 ENV GIT_TAG=$GIT_TAG

--- a/docker/Dockerfile.slim
+++ b/docker/Dockerfile.slim
@@ -2,8 +2,6 @@
 # compile stage
 #
 FROM alpine:3.20.1 AS compile-stage
-LABEL maintainer="Ralph Thesen <mail@redimp.de>"
-LABEL org.opencontainers.image.source="https://github.com/redimp/otterwiki"
 # install build environment (mostly necessary to build Pillow on armv6/7)
 RUN apk add python3 python3-dev py3-virtualenv \
             zlib-dev jpeg-dev gcc musl-dev libxml2-dev libxslt-dev
@@ -31,6 +29,8 @@ RUN pip install .
 # production stage
 #
 FROM alpine:3.20.1
+LABEL maintainer="Ralph Thesen <mail@redimp.de>"
+LABEL org.opencontainers.image.source="https://github.com/redimp/otterwiki"
 # arg for marking dev images
 ARG GIT_TAG
 ENV GIT_TAG=$GIT_TAG


### PR DESCRIPTION
Related to #387.

At the moment it seems like labels are missing from the final docker image.
As described [here](https://docs.docker.com/engine/manage-resources/labels/#images), those should be found in `.Config.Labels`
```
❯ docker image pull redimp/otterwiki:2.18.0-slim
2.18.0-slim: Pulling from redimp/otterwiki
...
Digest: sha256:594867b847a3b3f1dd7afb69bca353a5b50fafad0b0359eee1a32f1cd6fdb3a0
Status: Downloaded newer image for redimp/otterwiki:2.18.0-slim
docker.io/redimp/otterwiki:2.18.0-slim

❯ docker inspect redimp/otterwiki:2.18.0-slim | jq '.[].Config.Labels'
null
```

After applying this small fix, this is resolved:
```
❯ docker build -t otterwiki-local-slim -f docker/Dockerfile.slim .
...
 => exporting to image                                                                                                                  0.0s
 => => exporting layers                                                                                                                 0.0s
 => => writing image sha256:00933db4512bd71b785b19d12be409dd04d5551002d509d375babbbdac6d055a                                            0.0s
 => => naming to docker.io/library/otterwiki-local-slim                                                                                 0.0s
❯ docker inspect otterwiki-local-slim | jq '.[].Config.Labels'
{
  "maintainer": "Ralph Thesen <mail@redimp.de>",
  "org.opencontainers.image.source": "https://github.com/redimp/otterwiki"
}
```