### PR TITLE
fix: replace eval() in editor preview with direct DataTables reinit

### DIFF
--- a/otterwiki/templates/editor.html
+++ b/otterwiki/templates/editor.html
@@ -670,16 +670,11 @@ thx to https://github.com/sparksuite/simplemde-markdown-editor/issues/328#issuec
                 preview_block.innerHTML = data.preview_content;
                 sidebar_toc.innerHTML = data.preview_toc;
                 extranav_toc.innerHTML = data.preview_toc;
-                if (data.preview_js)
-                {
-                    try {
-                        eval(data.preview_js);
-                    }
-                    catch(e) {
-                        console.log("Error", e.stack);
-                        console.log("Error", e.name);
-                        console.log("Error", e.message);
-                    }
+                // Re-initialise DataTables in the preview pane without eval()
+                if (typeof simpleDatatables !== 'undefined') {
+                    preview_block.querySelectorAll("table[id^='s-dt-']").forEach(function(el) {
+                        new simpleDatatables.DataTable(el);
+                    });
                 }
             })
             .then(function () {

--- a/otterwiki/wiki.py
+++ b/otterwiki/wiki.py
@@ -655,13 +655,10 @@ class Page:
             breadcrumbs=self.breadcrumbs(),
         )
 
-        preview_js = "".join(collect_hook("renderer_javascript"))
-
         return {
             "preview_content": preview_html,
             "preview_toc": toc_html,
             "library_requirements": library_requirements,
-            "preview_js": preview_js,
         }
 
     def editor(self, author, handle_draft=None):


### PR DESCRIPTION
Remove the eval(data.preview_js) call in the editor live-preview fetch handler and replace it with a targeted simpleDatatables reinit loop over tables matching the known id prefix. Also remove preview_js from the server-side preview JSON response, eliminating the eval attack surface at the API level. DataTables is already unconditionally loaded in the editor page via force_load_libraries, so the reinit works without any additional script loading.