### PR TITLE
feat(auth): add /.well-known/change-password redirect to settings

### DIFF
--- a/otterwiki/views.py
+++ b/otterwiki/views.py
@@ -91,6 +91,11 @@ def favicon():
     )
 
 
+@app.route("/.well-known/change-password")
+def well_known_change_password():
+    return redirect(url_for("settings"))
+
+
 @app.route("/-/healthz")
 def healthz():
     healthy, msgs = health_check()

--- a/tests/test_essentials.py
+++ b/tests/test_essentials.py
@@ -28,3 +28,9 @@ def test_fatal_error():
         fatal_error("test_fatal_error")
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 1
+
+
+def test_well_known_change_password(test_client):
+    response = test_client.get("/.well-known/change-password")
+    assert response.status_code == 302
+    assert "/-/settings" in response.headers["Location"]


### PR DESCRIPTION
Implements the W3C well-known change password URL spec (https://w3c.github.io/webappsec-change-password-url/) so that browsers and password managers can direct users directly to the password change page.