### PR TITLE
fix(ui): preserve indentation in commit diff view

### DIFF
--- a/otterwiki/static/css/partials/history.css
+++ b/otterwiki/static/css/partials/history.css
@@ -16,6 +16,7 @@ table.diff tr.removed,
 table.diff td.value,
 table.diff td.hunk {
     font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
+    white-space: pre-wrap;
 }
 tr.removed {
     color: rgba(0, 0, 0, 0.85);


### PR DESCRIPTION
Add white-space: pre-wrap to diff table CSS so leading spaces are not collapsed by the browser, matching the blame view behavior.