### PR TITLE
Fixed improper text wrapping in sidebar.

### DIFF
--- a/otterwiki/static/css/partials/sidebar.css
+++ b/otterwiki/static/css/partials/sidebar.css
@@ -130,18 +130,18 @@ a.sidebar-toc-6 { padding-left: calc(7 * var(--spacing) - var(--radius) - 13px);
     padding-left : calc(2 * var(--spacing) - var(--radius) + 0.5rem);
     color: rgba(0,0,0,.7);
     padding-top: 0.5rem;
-    word-break: break-all;
+    word-break: break-word;
     box-sizing: border-box;
 }
 
 .sidebarmenu li > div.summary-details {
     box-sizing: inherit;
-    word-break: break-all;
+    word-break: break-word;
     list-style: none;
 }
 
 .sidebarmenu li > div.summary-details > a {
-    word-break: break-all;
+    word-break: break-word;
 }
 
 .parent-sidebar-menu > li {


### PR DESCRIPTION
Currently, the text in the sidebar is not wrapping properly.  It is breaking on any character, instead of by word.  This small css change fixes that!

Before:
<img width="285" height="430" alt="Screenshot 2026-04-22 102354" src="https://github.com/user-attachments/assets/714dae00-fe3f-4845-a616-25bf86d22346" />

After:
<img width="278" height="408" alt="Screenshot 2026-04-22 102424" src="https://github.com/user-attachments/assets/98387553-f7e7-4a7f-92c5-2e609984fc60" />
