### PR TITLE
Security check report for housekeeping

### DIFF
--- a/otterwiki/security_check.py
+++ b/otterwiki/security_check.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python
+# vim: set et ts=8 sts=4 sw=4 ai:
+
+"""
+otterwiki.security_check
+
+Extensible security check framework for Otterwiki.
+Each check is a function registered via the @register_backend_check decorator
+that returns a SecurityCheckResult (or a list of) if an issue is found, None otherwise.
+"""
+
+import os
+import re
+import ipaddress
+
+from flask import request
+from otterwiki.server import app
+from otterwiki.plugins import plugin_manager
+from otterwiki.util import empty
+
+
+class SecurityCheckResult:
+    """Represents a single security check finding."""
+
+    def __init__(self, issue, description, severity):
+        self.issue = issue
+        self.description = description
+        self.severity = severity
+
+    def to_dict(self):
+        return {
+            "issue": self.issue,
+            "description": self.description,
+            "severity": self.severity,
+        }
+
+
+# registry of backend check functions
+_backend_checks = []
+
+
+def register_backend_check(func):
+    """Decorator to register a backend security check function."""
+    _backend_checks.append(func)
+    return func
+
+
+def run_backend_checks():
+    """Run all registered backend security checks and return results as a list of dicts."""
+    results = []
+    for check_func in _backend_checks:
+        try:
+            result = check_func()
+            if result is not None:
+                if isinstance(result, list):
+                    results.extend(r.to_dict() for r in result)
+                else:
+                    results.append(result.to_dict())
+        except Exception as e:
+            app.logger.warning(
+                f"Security check '{check_func.__name__}' failed: {e}"
+            )
+    return results
+
+
+#
+# helper functions
+#
+
+
+def _get_custom_dir():
+    """Get the custom files directory path, respecting USE_STATIC_PATH env var."""
+    return os.path.join(
+        os.getenv(
+            "USE_STATIC_PATH",
+            os.path.join(app.root_path, "static"),
+        ),
+        "custom",
+    )
+
+
+def _has_css_rules(content):
+    """Check if CSS content has actual rules beyond comments and whitespace."""
+    content = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    content = content.strip()
+    return bool(content)
+
+
+def _has_js_code(content):
+    """Check if JS content has actual code beyond comments and whitespace."""
+    content = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    content = re.sub(r"//.*$", "", content, flags=re.MULTILINE)
+    content = content.strip()
+    return bool(content)
+
+
+def _has_html_content(content):
+    """Check if HTML content has actual content beyond comments and whitespace."""
+    content = re.sub(r"<!--.*?-->", "", content, flags=re.DOTALL)
+    content = content.strip()
+    return bool(content)
+
+
+def _is_private_ip(ip_str):
+    """Check if an IP address is private or loopback."""
+    try:
+        ip = ipaddress.ip_address(ip_str)
+        return ip.is_private or ip.is_loopback
+    except ValueError:
+        return False
+
+
+#
+# backend security checks
+#
+
+
+@register_backend_check
+def check_anonymous_write_access():
+    """Check if anonymous users can edit the wiki."""
+    if app.config.get("WRITE_ACCESS", "").upper() == "ANONYMOUS":
+        return SecurityCheckResult(
+            issue="Anonymous users can edit the wiki",
+            description=(
+                "Anonymous users have write access to your wiki, allowing anyone "
+                "to create or edit pages without logging in. Unless this is "
+                "intentional, it is a significant security risk. "
+                'This can be changed on the <a href="/-/admin/permissions_and_registration">'
+                "Permissions and Registration</a> page."
+            ),
+            severity="CRITICAL",
+        )
+    return None
+
+
+@register_backend_check
+def check_anonymous_upload_access():
+    """Check if anonymous users can upload files."""
+    if app.config.get("ATTACHMENT_ACCESS", "").upper() == "ANONYMOUS":
+        return SecurityCheckResult(
+            issue="Anonymous users can upload files",
+            description=(
+                "Anonymous users have file upload access to your wiki, allowing "
+                "anyone to upload files without logging in. Unless this is "
+                "intentional, it is a significant security risk. "
+                'This can be changed on the <a href="/-/admin/permissions_and_registration">'
+                "Permissions and Registration</a> page."
+            ),
+            severity="CRITICAL",
+        )
+    return None
+
+
+@register_backend_check
+def check_server_name_not_set():
+    """Check if SERVER_NAME is configured."""
+    if not app.config.get("SERVER_NAME"):
+        return SecurityCheckResult(
+            issue="Server name not configured",
+            description=(
+                "The <code>SERVER_NAME</code> configuration variable is not set. "
+                "This may lead to issues depending on your reverse proxy configuration. "
+                'See <a href="https://flask.palletsprojects.com/en/stable/config/#SERVER_NAME">'
+                "Flask documentation</a> for details. "
+                'This can be changed on the <a href="/-/admin">'
+                "Application Preferences</a> page."
+            ),
+            severity="NOTICE",
+        )
+    return None
+
+
+@register_backend_check
+def check_open_registrations():
+    """Check if registrations are fully open without any restrictions."""
+    if (
+        not app.config.get("DISABLE_REGISTRATION", False)
+        and not app.config.get("EMAIL_NEEDS_CONFIRMATION", True)
+        and app.config.get("AUTO_APPROVAL", True)
+    ):
+        return SecurityCheckResult(
+            issue="Fully open registrations",
+            description=(
+                "Your wiki allows unlimited registrations without requiring "
+                "email confirmation or manual approval. This means anyone can "
+                "create accounts without restrictions, potentially flooding the "
+                "wiki with spam users. "
+                'This can be changed on the <a href="/-/admin/permissions_and_registration">'
+                "Permissions and Registration</a> page."
+            ),
+            severity="HIGH",
+        )
+    return None
+
+
+@register_backend_check
+def check_plugins_active():
+    """Check if plugins are active."""
+    plugin_info = plugin_manager.list_plugin_distinfo()
+    if plugin_info:
+        plugin_names = [dist.project_name for _, dist in plugin_info]
+        return SecurityCheckResult(
+            issue="Plugins are active",
+            description=(
+                "You are using wiki plugins. Note that there are "
+                "little to no restrictions on what a plugin can do, and "
+                "third-party plugins are not reviewed for security by an Otterwiki "
+                "developers. Your active plugins: "
+                f"<strong>{', '.join(plugin_names)}</strong>."
+            ),
+            severity="NOTICE",
+        )
+    return None
+
+
+@register_backend_check
+def check_custom_css():
+    """Check if custom CSS rules are defined."""
+    custom_dir = _get_custom_dir()
+    css_path = os.path.join(custom_dir, "custom.css")
+    try:
+        if os.path.exists(css_path):
+            with open(css_path, "r") as f:
+                content = f.read()
+            if _has_css_rules(content):
+                return SecurityCheckResult(
+                    issue="Custom CSS is being used",
+                    description=(
+                        "You have custom CSS rules defined in "
+                        "<code>custom.css</code>. If this is intentional, "
+                        "this notice can be ignored."
+                    ),
+                    severity="NOTICE",
+                )
+    except Exception:
+        pass
+    return None
+
+
+@register_backend_check
+def check_custom_js():
+    """Check if custom JavaScript code is defined."""
+    custom_dir = _get_custom_dir()
+    js_path = os.path.join(custom_dir, "custom.js")
+    try:
+        if os.path.exists(js_path):
+            with open(js_path, "r") as f:
+                content = f.read()
+            if _has_js_code(content):
+                return SecurityCheckResult(
+                    issue="Custom JavaScript is being used",
+                    description=(
+                        "You have custom JavaScript code defined in "
+                        "<code>custom.js</code>. If this is intentional, "
+                        "this notice can be ignored."
+                    ),
+                    severity="NOTICE",
+                )
+    except Exception:
+        pass
+    return None
+
+
+@register_backend_check
+def check_custom_html():
+    """Check if custom HTML content is being used."""
+    findings = []
+    custom_dir = _get_custom_dir()
+
+    head_path = os.path.join(custom_dir, "customHead.html")
+    try:
+        if os.path.exists(head_path):
+            with open(head_path, "r") as f:
+                content = f.read()
+            if _has_html_content(content):
+                findings.append("customHead.html")
+    except Exception:
+        pass
+
+    body_path = os.path.join(custom_dir, "customBody.html")
+    try:
+        if os.path.exists(body_path):
+            with open(body_path, "r") as f:
+                content = f.read()
+            if _has_html_content(content):
+                findings.append("customBody.html")
+    except Exception:
+        pass
+
+    if not empty(app.config.get("HTML_EXTRA_HEAD", "")):
+        findings.append("HTML_EXTRA_HEAD")
+
+    if not empty(app.config.get("HTML_EXTRA_BODY", "")):
+        findings.append("HTML_EXTRA_BODY")
+
+    if findings:
+        return SecurityCheckResult(
+            issue="Custom HTML is being used",
+            description=(
+                "You have custom HTML defined in: <strong>"
+                + ", ".join(findings)
+                + "</strong>. If this is intentional, this notice can be ignored."
+            ),
+            severity="NOTICE",
+        )
+    return None
+
+
+@register_backend_check
+def check_html_whitelist():
+    """Check if RENDERER_HTML_ALLOWLIST is configured."""
+    if not empty(app.config.get("RENDERER_HTML_ALLOWLIST", "")):
+        return SecurityCheckResult(
+            issue="Custom HTML allowlist is configured",
+            description=(
+                "Your <code>RENDERER_HTML_ALLOWLIST</code> is not empty, which "
+                "allows potentially unsafe additional HTML tags and attributes "
+                "in wiki content. If this is intentional, this notice can be "
+                "ignored."
+            ),
+            severity="NOTICE",
+        )
+    return None
+
+
+@register_backend_check
+def check_reverse_proxy():
+    """Check for missing or misconfigured reverse proxy.
+
+    Triggers in these cases:
+    - Request from a non-private IP with no proxy headers > likely no reverse proxy at all
+    - REAL_IP_FROM is configured but proxy headers are missing > misconfigured proxy
+    - Proxy headers are present but REAL_IP_FROM is not configured > incomplete proxy setup
+    """
+    real_ip_from_configured = not empty(
+        str(app.config.get("REAL_IP_FROM", ""))
+    )
+    has_real_ip = bool(request.headers.get("X-Real-IP"))
+    has_forwarded_for = bool(request.headers.get("X-Forwarded-For"))
+    has_forwarded_proto = bool(request.headers.get("X-Forwarded-Proto"))
+    has_proxy_headers = has_real_ip or has_forwarded_for or has_forwarded_proto
+    remote_addr = request.remote_addr
+    is_private = _is_private_ip(remote_addr)
+
+    # direct local access without any proxy config/headers is likely fine
+    if is_private and not real_ip_from_configured and not has_proxy_headers:
+        return None
+
+    issues = []
+    issue_title = "Misconfigured reverse proxy"
+
+    # non-private IP with no proxy headers
+    if (
+        not is_private
+        and not has_proxy_headers
+        and not real_ip_from_configured
+    ):
+        issue_title = "Missing or misconfigured reverse proxy"
+        issues.append(
+            "Your wiki is directly accessible from the internet without a "
+            "reverse proxy or the reverse proxy is misconfigured."
+            "This is not recommended as it exposes the "
+            "application server directly."
+        )
+
+    # REAL_IP_FROM configured but no proxy headers arriving
+    if real_ip_from_configured and not has_real_ip and not has_forwarded_for:
+        issues.append(
+            "<code>REAL_IP_FROM</code> is configured but no "
+            "<code>X-Real-IP</code> or <code>X-Forwarded-For</code> "
+            "header is being sent by your reverse proxy."
+        )
+
+    # proxy headers present but REAL_IP_FROM not configured
+    if has_proxy_headers and not real_ip_from_configured:
+        issues.append(
+            "Proxy headers are present but <code>REAL_IP_FROM</code> is "
+            "not configured, so the wiki cannot determine the real client IP."
+        )
+
+    # X-Forwarded-For present but X-Forwarded-Proto missing
+    if has_forwarded_for and not has_forwarded_proto:
+        issues.append(
+            "<code>X-Forwarded-For</code> is present but "
+            "<code>X-Forwarded-Proto</code> is not, so the wiki cannot "
+            "determine the original protocol."
+        )
+
+    # REAL_IP_FROM configured but X-Forwarded-Proto missing
+    if real_ip_from_configured and not has_forwarded_proto:
+        issues.append(
+            "No <code>X-Forwarded-Proto</code> header is being sent, "
+            "so the wiki cannot determine the original protocol."
+        )
+
+    if issues:
+        # HIGH severity if we suspect no reverse proxy exists at all
+        suspected_no_proxy = (
+            not is_private
+            and not has_proxy_headers
+            and not real_ip_from_configured
+        )
+        # HIGH severity if there is a proxy but X-Forwarded-Proto is missing
+        proxy_without_proto = (
+            has_proxy_headers or real_ip_from_configured
+        ) and not has_forwarded_proto
+
+        severity = (
+            "HIGH" if (suspected_no_proxy or proxy_without_proto) else "MEDIUM"
+        )
+
+        issues_list = "".join(f"<li>{issue}</li>" for issue in issues)
+        return SecurityCheckResult(
+            issue=issue_title,
+            description=(
+                "Your wiki does not appear to be running behind a properly "
+                "configured reverse proxy:"
+                f"<ul>{issues_list}</ul>"
+                "Please consult the documentation for "
+                '<a href="https://otterwiki.com/Installation#reverse-proxy">'
+                "example reverse proxy configurations</a> and "
+                '<a href="https://otterwiki.com/Configuration#reverse-proxy-and-ips">'
+                "required wiki parameters</a>."
+            ),
+            severity=severity,
+        )
+
+    return None

--- a/otterwiki/security_check.py
+++ b/otterwiki/security_check.py
@@ -124,6 +124,37 @@ def _is_private_ip(ip_str):
         return False
 
 
+def _is_loopback_host():
+    """Return True if the request's Host header points at loopback.
+
+    Used to downgrade severity on local/dev access; the wiki may still be
+    reachable via tunnel or port forward, so the downgrade is communicated
+    in the description.
+    """
+    try:
+        host = request.host or ""
+    except RuntimeError:
+        return False
+    # strip port
+    if host.startswith("[") and "]" in host:
+        host = host[1 : host.index("]")]
+    elif ":" in host:
+        host = host.rsplit(":", 1)[0]
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+_LOOPBACK_NOTE = (
+    " <em>Severity reduced because the wiki was accessed via a loopback "
+    "host; if this server is reachable from elsewhere, treat this as "
+    "critical.</em>"
+)
+
+
 #
 # backend security checks
 #
@@ -133,16 +164,20 @@ def _is_private_ip(ip_str):
 def check_anonymous_write_access():
     """Check if anonymous users can edit the wiki."""
     if app.config.get("WRITE_ACCESS", "").upper() == "ANONYMOUS":
+        loopback = _is_loopback_host()
+        description = (
+            "Anonymous users have write access to your wiki, allowing anyone "
+            "to create or edit pages without logging in. Unless this is "
+            "intentional, it is a significant security risk. "
+            'This can be changed on the <a href="/-/admin/permissions_and_registration">'
+            "Permissions and Registration</a> page."
+        )
+        if loopback:
+            description += _LOOPBACK_NOTE
         return SecurityCheckResult(
             issue="Anonymous users can edit the wiki",
-            description=(
-                "Anonymous users have write access to your wiki, allowing anyone "
-                "to create or edit pages without logging in. Unless this is "
-                "intentional, it is a significant security risk. "
-                'This can be changed on the <a href="/-/admin/permissions_and_registration">'
-                "Permissions and Registration</a> page."
-            ),
-            severity="CRITICAL",
+            description=description,
+            severity="MEDIUM" if loopback else "CRITICAL",
         )
     return SecurityCheckResult(
         issue="Anonymous write access is disabled",
@@ -155,16 +190,20 @@ def check_anonymous_write_access():
 def check_anonymous_upload_access():
     """Check if anonymous users can upload files."""
     if app.config.get("ATTACHMENT_ACCESS", "").upper() == "ANONYMOUS":
+        loopback = _is_loopback_host()
+        description = (
+            "Anonymous users have file upload access to your wiki, allowing "
+            "anyone to upload files without logging in. Unless this is "
+            "intentional, it is a significant security risk. "
+            'This can be changed on the <a href="/-/admin/permissions_and_registration">'
+            "Permissions and Registration</a> page."
+        )
+        if loopback:
+            description += _LOOPBACK_NOTE
         return SecurityCheckResult(
             issue="Anonymous users can upload files",
-            description=(
-                "Anonymous users have file upload access to your wiki, allowing "
-                "anyone to upload files without logging in. Unless this is "
-                "intentional, it is a significant security risk. "
-                'This can be changed on the <a href="/-/admin/permissions_and_registration">'
-                "Permissions and Registration</a> page."
-            ),
-            severity="CRITICAL",
+            description=description,
+            severity="MEDIUM" if loopback else "CRITICAL",
         )
     return SecurityCheckResult(
         issue="Anonymous upload access is disabled",

--- a/otterwiki/security_check.py
+++ b/otterwiki/security_check.py
@@ -13,6 +13,7 @@ import os
 import re
 import ipaddress
 
+from bs4 import BeautifulSoup
 from flask import request
 from otterwiki.server import app
 from otterwiki.plugins import plugin_manager
@@ -96,9 +97,8 @@ def _has_js_code(content):
 
 def _has_html_content(content):
     """Check if HTML content has actual content beyond comments and whitespace."""
-    content = re.sub(r"<!--.*?-->", "", content, flags=re.DOTALL)
-    content = content.strip()
-    return bool(content)
+    soup = BeautifulSoup(content, "html.parser")
+    return bool(soup.get_text(strip=True)) or soup.find() is not None
 
 
 def _is_private_ip(ip_str):

--- a/otterwiki/security_check.py
+++ b/otterwiki/security_check.py
@@ -362,12 +362,8 @@ def check_reverse_proxy():
 
     Triggers in these cases:
     - Request from a non-private IP with no proxy headers > likely no reverse proxy at all
-    - REAL_IP_FROM is configured but proxy headers are missing > misconfigured proxy
-    - Proxy headers are present but REAL_IP_FROM is not configured > incomplete proxy setup
+    - X-Forwarded-For present but X-Forwarded-Proto missing > incomplete proxy setup
     """
-    real_ip_from_configured = not empty(
-        str(app.config.get("REAL_IP_FROM", ""))
-    )
     has_real_ip = bool(request.headers.get("X-Real-IP"))
     has_forwarded_for = bool(request.headers.get("X-Forwarded-For"))
     has_forwarded_proto = bool(request.headers.get("X-Forwarded-Proto"))
@@ -375,40 +371,21 @@ def check_reverse_proxy():
     remote_addr = request.remote_addr
     is_private = _is_private_ip(remote_addr)
 
-    # direct local access without any proxy config/headers is likely fine
-    if is_private and not real_ip_from_configured and not has_proxy_headers:
+    # direct local access without any proxy headers is likely fine
+    if is_private and not has_proxy_headers:
         return None
 
     issues = []
     issue_title = "Misconfigured reverse proxy"
 
     # non-private IP with no proxy headers
-    if (
-        not is_private
-        and not has_proxy_headers
-        and not real_ip_from_configured
-    ):
+    if not is_private and not has_proxy_headers:
         issue_title = "Missing or misconfigured reverse proxy"
         issues.append(
             "Your wiki is directly accessible from the internet without a "
-            "reverse proxy or the reverse proxy is misconfigured."
+            "reverse proxy or the reverse proxy is misconfigured. "
             "This is not recommended as it exposes the "
             "application server directly."
-        )
-
-    # REAL_IP_FROM configured but no proxy headers arriving
-    if real_ip_from_configured and not has_real_ip and not has_forwarded_for:
-        issues.append(
-            "<code>REAL_IP_FROM</code> is configured but no "
-            "<code>X-Real-IP</code> or <code>X-Forwarded-For</code> "
-            "header is being sent by your reverse proxy."
-        )
-
-    # proxy headers present but REAL_IP_FROM not configured
-    if has_proxy_headers and not real_ip_from_configured:
-        issues.append(
-            "Proxy headers are present but <code>REAL_IP_FROM</code> is "
-            "not configured, so the wiki cannot determine the real client IP."
         )
 
     # X-Forwarded-For present but X-Forwarded-Proto missing
@@ -419,24 +396,11 @@ def check_reverse_proxy():
             "determine the original protocol."
         )
 
-    # REAL_IP_FROM configured but X-Forwarded-Proto missing
-    if real_ip_from_configured and not has_forwarded_proto:
-        issues.append(
-            "No <code>X-Forwarded-Proto</code> header is being sent, "
-            "so the wiki cannot determine the original protocol."
-        )
-
     if issues:
         # HIGH severity if we suspect no reverse proxy exists at all
-        suspected_no_proxy = (
-            not is_private
-            and not has_proxy_headers
-            and not real_ip_from_configured
-        )
+        suspected_no_proxy = not is_private and not has_proxy_headers
         # HIGH severity if there is a proxy but X-Forwarded-Proto is missing
-        proxy_without_proto = (
-            has_proxy_headers or real_ip_from_configured
-        ) and not has_forwarded_proto
+        proxy_without_proto = has_proxy_headers and not has_forwarded_proto
 
         severity = (
             "HIGH" if (suspected_no_proxy or proxy_without_proto) else "MEDIUM"
@@ -460,8 +424,6 @@ def check_reverse_proxy():
 
     return SecurityCheckResult(
         issue="Reverse proxy looks correctly configured",
-        description=(
-            "Proxy headers and <code>REAL_IP_FROM</code> appear consistent."
-        ),
+        description="Proxy headers appear consistent.",
         passed=True,
     )

--- a/otterwiki/security_check.py
+++ b/otterwiki/security_check.py
@@ -21,19 +21,28 @@ from otterwiki.util import empty
 
 
 class SecurityCheckResult:
-    """Represents a single security check finding."""
+    """Represents a single security check result.
 
-    def __init__(self, issue, description, severity):
+    `passed=False` results are issues to display in the issues table
+    (severity is required). `passed=True` results are reported under
+    the "checks passed" table; severity is ignored there.
+    """
+
+    def __init__(self, issue, description, severity=None, passed=False):
         self.issue = issue
         self.description = description
         self.severity = severity
+        self.passed = passed
 
     def to_dict(self):
-        return {
+        d = {
             "issue": self.issue,
             "description": self.description,
-            "severity": self.severity,
+            "passed": self.passed,
         }
+        if not self.passed:
+            d["severity"] = self.severity
+        return d
 
 
 # registry of backend check functions
@@ -47,21 +56,26 @@ def register_backend_check(func):
 
 
 def run_backend_checks():
-    """Run all registered backend security checks and return results as a list of dicts."""
-    results = []
+    """Run all registered backend security checks.
+
+    Returns a dict ``{"issues": [...], "passed": [...]}`` where each
+    entry is the dict produced by :py:meth:`SecurityCheckResult.to_dict`.
+    """
+    issues = []
+    passed = []
     for check_func in _backend_checks:
         try:
             result = check_func()
-            if result is not None:
-                if isinstance(result, list):
-                    results.extend(r.to_dict() for r in result)
-                else:
-                    results.append(result.to_dict())
+            if result is None:
+                continue
+            results = result if isinstance(result, list) else [result]
+            for r in results:
+                (passed if r.passed else issues).append(r.to_dict())
         except Exception as e:
             app.logger.warning(
                 f"Security check '{check_func.__name__}' failed: {e}"
             )
-    return results
+    return {"issues": issues, "passed": passed}
 
 
 #
@@ -130,7 +144,11 @@ def check_anonymous_write_access():
             ),
             severity="CRITICAL",
         )
-    return None
+    return SecurityCheckResult(
+        issue="Anonymous write access is disabled",
+        description="Write access requires an authenticated account.",
+        passed=True,
+    )
 
 
 @register_backend_check
@@ -148,7 +166,11 @@ def check_anonymous_upload_access():
             ),
             severity="CRITICAL",
         )
-    return None
+    return SecurityCheckResult(
+        issue="Anonymous upload access is disabled",
+        description="Attachment uploads require an authenticated account.",
+        passed=True,
+    )
 
 
 @register_backend_check
@@ -167,7 +189,11 @@ def check_server_name_not_set():
             ),
             severity="NOTICE",
         )
-    return None
+    return SecurityCheckResult(
+        issue="Server name is configured",
+        description="The <code>SERVER_NAME</code> configuration variable is set.",
+        passed=True,
+    )
 
 
 @register_backend_check
@@ -190,7 +216,14 @@ def check_open_registrations():
             ),
             severity="HIGH",
         )
-    return None
+    return SecurityCheckResult(
+        issue="Registrations are restricted",
+        description=(
+            "New registrations are disabled or require email confirmation "
+            "or manual approval."
+        ),
+        passed=True,
+    )
 
 
 @register_backend_check
@@ -425,4 +458,10 @@ def check_reverse_proxy():
             severity=severity,
         )
 
-    return None
+    return SecurityCheckResult(
+        issue="Reverse proxy looks correctly configured",
+        description=(
+            "Proxy headers and <code>REAL_IP_FROM</code> appear consistent."
+        ),
+        passed=True,
+    )

--- a/otterwiki/static/css/otterwiki.css
+++ b/otterwiki/static/css/otterwiki.css
@@ -545,3 +545,25 @@ mark {
     /* override halfmoon's form control font size to prevent mobile zoom */
     font-size: 16px;
 }
+
+/* additional badge variants (halfmoon ships only primary/success/secondary/danger) */
+.badge.badge-warning {
+    color: var(--text-color-on-orange-color-bg);
+    background-color: var(--orange-color);
+    border-color: var(--orange-color);
+}
+.dark-mode .badge.badge-warning {
+    color: var(--text-color-on-orange-color-bg);
+    background-color: var(--orange-color);
+    border-color: var(--orange-color);
+}
+.badge.badge-notice {
+    color: #ffffff;
+    background-color: var(--gray-color-very-dark);
+    border-color: var(--gray-color-very-dark);
+}
+.dark-mode .badge.badge-notice {
+    color: rgba(0, 0, 0, 0.85);
+    background-color: var(--gray-color);
+    border-color: var(--gray-color);
+}

--- a/otterwiki/templates/tools/housekeeping.html
+++ b/otterwiki/templates/tools/housekeeping.html
@@ -215,6 +215,16 @@
         }
     }
 
+    function isLoopbackHost() {
+        var h = window.location.hostname || '';
+        if (h === 'localhost') return true;
+        if (/^127\./.test(h)) return true;
+        if (h === '::1' || h === '[::1]') return true;
+        return false;
+    }
+
+    var loopbackNote = ' <em>Severity reduced because the wiki was accessed via a loopback host; if this server is reachable from elsewhere, treat this as critical.</em>';
+
     // Frontend security checks (runs alongside backend checks).
     // Returns {issues: [...], passed: [...]}.
     function runFrontendChecks(backendResponse) {
@@ -223,10 +233,13 @@
 
         // HTTPS
         if (window.location.protocol !== 'https:') {
+            var loopback = isLoopbackHost();
+            var description = 'SSL is not enabled for your wiki. Unless you are using the wiki in a local environment only, this is a major security risk. The easiest way to add SSL is via a reverse proxy, see <a href="https://otterwiki.com/Installation#reverse-proxy">the documentation</a>.';
+            if (loopback) description += loopbackNote;
             issues.push({
                 issue: 'HTTPS not enabled',
-                description: 'SSL is not enabled for your wiki. Unless you are using the wiki in a local environment only, this is a major security risk. The easiest way to add SSL is via a reverse proxy, see <a href="https://otterwiki.com/Installation#reverse-proxy">the documentation</a>.',
-                severity: 'CRITICAL'
+                description: description,
+                severity: loopback ? 'MEDIUM' : 'CRITICAL'
             });
         } else {
             passed.push({

--- a/otterwiki/templates/tools/housekeeping.html
+++ b/otterwiki/templates/tools/housekeeping.html
@@ -111,6 +111,21 @@
 <div id="security-check-error" style="display:none;">
 <p class="text-danger"><em>An error occurred while running the security check.</em></p>
 </div>
+<div id="security-check-passed-wrapper" class="mt-10" style="display:none;">
+    <button class="btn btn-secondary btn-sm" id="security-check-passed-toggle" type="button" onclick="otterwiki.toggle_security_check_passed()">Show passed checks (<span id="security-check-passed-count">0</span>)</button>
+    <div id="security-check-passed" style="display:none;" class="mt-10">
+    <table class="table compact" style="table-layout: fixed; width: 100%;">
+        <thead>
+            <tr>
+                <th style="width: 200px;"><strong>Check</strong></th>
+                <th><strong>Description</strong></th>
+            </tr>
+        </thead>
+        <tbody id="security-check-passed-tbody">
+        </tbody>
+    </table>
+    </div>
+</div>
 <div class="mt-10">
     <button class="btn btn-primary" id="security-check-btn" onclick="otterwiki.run_security_check()">Perform security check</button>
 </div>
@@ -122,6 +137,7 @@
 {% block js %}
 {{ super() }}
 <script src="{{ url_for("static", filename="js/htmx.2.0.8.min.js") }}" type="text/javascript" charset="utf-8"></script>
+{% if has_permission("ADMIN") %}
 <script type="text/javascript">
 // otterwiki security check frontend checks and display logic
 (function() {
@@ -139,13 +155,13 @@
         return '<span class="badge badge-pill ' + cls + '">' + severity + '</span>';
     }
 
-    function renderResults(results) {
+    function renderIssues(issues) {
         var tbody = document.getElementById('security-check-tbody');
         tbody.innerHTML = '';
         var resultsDiv = document.getElementById('security-check-results');
         var emptyDiv = document.getElementById('security-check-empty');
 
-        if (results.length === 0) {
+        if (issues.length === 0) {
             resultsDiv.style.display = 'none';
             emptyDiv.style.display = '';
             return;
@@ -155,7 +171,7 @@
         resultsDiv.style.display = '';
 
         var severityLevels = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'NOTICE'];
-        results.sort(function(a, b) {
+        issues.sort(function(a, b) {
             var aIdx = severityLevels.indexOf(a.severity);
             var bIdx = severityLevels.indexOf(b.severity);
             if (aIdx < 0) aIdx = 99;
@@ -163,8 +179,8 @@
             return aIdx - bIdx;
         });
 
-        for (var i = 0; i < results.length; i++) {
-            var r = results[i];
+        for (var i = 0; i < issues.length; i++) {
+            var r = issues[i];
             var tr = document.createElement('tr');
             tr.innerHTML =
                 '<td style="overflow-wrap: break-word; word-wrap: break-word;"><strong>' + r.issue + '</strong></td>' +
@@ -174,16 +190,68 @@
         }
     }
 
-    // Frontend security checks (runs alongside backend checks)
-    function runFrontendChecks(backendResponse) {
-        var results = [];
+    function renderPassed(passed) {
+        var wrapper = document.getElementById('security-check-passed-wrapper');
+        var tbody = document.getElementById('security-check-passed-tbody');
+        var countSpan = document.getElementById('security-check-passed-count');
+        var panel = document.getElementById('security-check-passed');
+        var toggle = document.getElementById('security-check-passed-toggle');
 
-        // HTTPS not enabled
+        tbody.innerHTML = '';
+        // collapse on each new run
+        panel.style.display = 'none';
+        toggle.textContent = '';
+
+        if (passed.length === 0) {
+            wrapper.style.display = 'none';
+            return;
+        }
+
+        wrapper.style.display = '';
+        countSpan.textContent = passed.length;
+        toggle.appendChild(document.createTextNode('Show passed checks ('));
+        toggle.appendChild(countSpan);
+        toggle.appendChild(document.createTextNode(')'));
+
+        for (var i = 0; i < passed.length; i++) {
+            var r = passed[i];
+            var tr = document.createElement('tr');
+            tr.innerHTML =
+                '<td style="overflow-wrap: break-word; word-wrap: break-word;"><strong>' + r.issue + '</strong></td>' +
+                '<td style="overflow-wrap: break-word; word-wrap: break-word;">' + r.description + '</td>';
+            tbody.appendChild(tr);
+        }
+    }
+
+    otterwiki.toggle_security_check_passed = function() {
+        var panel = document.getElementById('security-check-passed');
+        var toggle = document.getElementById('security-check-passed-toggle');
+        var countSpan = document.getElementById('security-check-passed-count');
+        var visible = panel.style.display !== 'none';
+        panel.style.display = visible ? 'none' : '';
+        toggle.textContent = '';
+        toggle.appendChild(document.createTextNode((visible ? 'Show' : 'Hide') + ' passed checks ('));
+        toggle.appendChild(countSpan);
+        toggle.appendChild(document.createTextNode(')'));
+    };
+
+    // Frontend security checks (runs alongside backend checks).
+    // Returns {issues: [...], passed: [...]}.
+    function runFrontendChecks(backendResponse) {
+        var issues = [];
+        var passed = [];
+
+        // HTTPS
         if (window.location.protocol !== 'https:') {
-            results.push({
+            issues.push({
                 issue: 'HTTPS not enabled',
                 description: 'SSL is not enabled for your wiki. Unless you are using the wiki in a local environment only, this is a major security risk. The easiest way to add SSL is via a reverse proxy, see <a href="https://otterwiki.com/Installation#reverse-proxy">the documentation</a>.',
                 severity: 'CRITICAL'
+            });
+        } else {
+            passed.push({
+                issue: 'HTTPS is enabled',
+                description: 'The wiki was loaded over an encrypted connection.'
             });
         }
 
@@ -193,15 +261,20 @@
         if (backendResponse) {
             var csp = backendResponse.headers.get('Content-Security-Policy');
             if (!csp) {
-                results.push({
+                issues.push({
                     issue: 'CSP header missing',
                     description: 'The Content Security Policy header is not set, which means resources could be loaded from any origin. This makes the wiki more vulnerable to cross-site scripting attacks. <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP">Learn more about CSP</a>.',
                     severity: 'LOW'
                 });
+            } else {
+                passed.push({
+                    issue: 'CSP header is set',
+                    description: 'A Content Security Policy header was returned by the server.'
+                });
             }
         }
 
-        return results;
+        return {issues: issues, passed: passed};
     }
 
     // Main entry point
@@ -213,20 +286,21 @@
         btn.disabled = true;
         btn.textContent = 'Running security check\u2026';
 
-        // Run backend checks and also use the response for CSP header check
         fetch('/-/housekeeping/security-check', {
             method: 'GET',
             credentials: 'same-origin'
         }).then(function(response) {
             if (!response.ok) throw new Error('Backend check failed');
-            // Run frontend checks using this response for header inspection
-            var frontendResults = runFrontendChecks(response);
+            var frontend = runFrontendChecks(response);
             return response.json().then(function(data) {
-                var backendResults = data.results || [];
-                return backendResults.concat(frontendResults);
+                return {
+                    issues: (data.issues || []).concat(frontend.issues),
+                    passed: (data.passed || []).concat(frontend.passed)
+                };
             });
-        }).then(function(allResults) {
-            renderResults(allResults);
+        }).then(function(combined) {
+            renderIssues(combined.issues);
+            renderPassed(combined.passed);
         }).catch(function(err) {
             console.error('Security check error:', err);
             errorDiv.style.display = '';
@@ -237,4 +311,5 @@
     };
 })();
 </script>
+{% endif %}
 {% endblock js %}

--- a/otterwiki/templates/tools/housekeeping.html
+++ b/otterwiki/templates/tools/housekeeping.html
@@ -87,6 +87,7 @@
 </div>
 {% endif %}
 {#-#}
+{% if has_permission("ADMIN") %}
 <div class="card m-auto m-lg-20">
 <div class="mw-full">
 <h3 class="card-title">Security Check</h3>
@@ -115,6 +116,7 @@
 </div>
 </div>
 </div>
+{% endif %}
 {#-#}
 {% endblock %}{# content #}
 {% block js %}

--- a/otterwiki/templates/tools/housekeeping.html
+++ b/otterwiki/templates/tools/housekeeping.html
@@ -125,18 +125,18 @@
 <script type="text/javascript">
 // otterwiki security check frontend checks and display logic
 (function() {
-    // Severity level colors for badge styling
-    var severityStyles = {
-        CRITICAL: { bg: '#dc3545', color: '#fff' },
-        HIGH:     { bg: '#e67e22', color: '#fff' },
-        MEDIUM:   { bg: '#f0ad4e', color: '#fff' },
-        LOW:      { bg: '#5bc0de', color: '#fff' },
-        NOTICE:   { bg: '#6c757d', color: '#fff' },
+    // Severity level to halfmoon/otterwiki badge class
+    var severityBadgeClass = {
+        CRITICAL: 'badge-danger',
+        HIGH:     'badge-warning',
+        MEDIUM:   'badge-secondary',
+        LOW:      'badge-primary',
+        NOTICE:   'badge-notice',
     };
 
     function severityBadge(severity) {
-        var style = severityStyles[severity] || severityStyles.NOTICE;
-        return '<span class="badge badge-pill" style="background-color:' + style.bg + ';color:' + style.color + ';font-weight:bold;">' + severity + '</span>';
+        var cls = severityBadgeClass[severity] || severityBadgeClass.NOTICE;
+        return '<span class="badge badge-pill ' + cls + '">' + severity + '</span>';
     }
 
     function renderResults(results) {

--- a/otterwiki/templates/tools/housekeeping.html
+++ b/otterwiki/templates/tools/housekeeping.html
@@ -87,8 +87,152 @@
 </div>
 {% endif %}
 {#-#}
+<div class="card m-auto m-lg-20">
+<div class="mw-full">
+<h3 class="card-title">Security Check</h3>
+<p class="text-muted">The security check provides an overview of your wiki's security, highlighting potentially problematic issues. It is purely informational and safe to run in any environment at any time.</p>
+<div id="security-check-results" style="display:none;">
+<table class="table compact" style="table-layout: fixed; width: 100%;">
+    <thead>
+        <tr>
+            <th style="width: 200px;"><strong>Issue</strong></th>
+            <th style="width: 110px; text-align: center;"><strong>Severity</strong></th>
+            <th><strong>Description</strong></th>
+        </tr>
+    </thead>
+    <tbody id="security-check-tbody">
+    </tbody>
+</table>
+</div>
+<div id="security-check-empty" style="display:none;">
+<p class="text-muted"><em>No security issues found. Your wiki looks good!</em></p>
+</div>
+<div id="security-check-error" style="display:none;">
+<p class="text-danger"><em>An error occurred while running the security check.</em></p>
+</div>
+<div class="mt-10">
+    <button class="btn btn-primary" id="security-check-btn" onclick="otterwiki.run_security_check()">Perform security check</button>
+</div>
+</div>
+</div>
+{#-#}
 {% endblock %}{# content #}
 {% block js %}
 {{ super() }}
 <script src="{{ url_for("static", filename="js/htmx.2.0.8.min.js") }}" type="text/javascript" charset="utf-8"></script>
+<script type="text/javascript">
+// otterwiki security check frontend checks and display logic
+(function() {
+    // Severity level colors for badge styling
+    var severityStyles = {
+        CRITICAL: { bg: '#dc3545', color: '#fff' },
+        HIGH:     { bg: '#e67e22', color: '#fff' },
+        MEDIUM:   { bg: '#f0ad4e', color: '#fff' },
+        LOW:      { bg: '#5bc0de', color: '#fff' },
+        NOTICE:   { bg: '#6c757d', color: '#fff' },
+    };
+
+    function severityBadge(severity) {
+        var style = severityStyles[severity] || severityStyles.NOTICE;
+        return '<span class="badge badge-pill" style="background-color:' + style.bg + ';color:' + style.color + ';font-weight:bold;">' + severity + '</span>';
+    }
+
+    function renderResults(results) {
+        var tbody = document.getElementById('security-check-tbody');
+        tbody.innerHTML = '';
+        var resultsDiv = document.getElementById('security-check-results');
+        var emptyDiv = document.getElementById('security-check-empty');
+
+        if (results.length === 0) {
+            resultsDiv.style.display = 'none';
+            emptyDiv.style.display = '';
+            return;
+        }
+
+        emptyDiv.style.display = 'none';
+        resultsDiv.style.display = '';
+
+        var severityLevels = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'NOTICE'];
+        results.sort(function(a, b) {
+            var aIdx = severityLevels.indexOf(a.severity);
+            var bIdx = severityLevels.indexOf(b.severity);
+            if (aIdx < 0) aIdx = 99;
+            if (bIdx < 0) bIdx = 99;
+            return aIdx - bIdx;
+        });
+
+        for (var i = 0; i < results.length; i++) {
+            var r = results[i];
+            var tr = document.createElement('tr');
+            tr.innerHTML =
+                '<td style="overflow-wrap: break-word; word-wrap: break-word;"><strong>' + r.issue + '</strong></td>' +
+                '<td style="text-align: center;">' + severityBadge(r.severity) + '</td>' +
+                '<td style="overflow-wrap: break-word; word-wrap: break-word;">' + r.description + '</td>';
+            tbody.appendChild(tr);
+        }
+    }
+
+    // Frontend security checks (runs alongside backend checks)
+    function runFrontendChecks(backendResponse) {
+        var results = [];
+
+        // HTTPS not enabled
+        if (window.location.protocol !== 'https:') {
+            results.push({
+                issue: 'HTTPS not enabled',
+                description: 'SSL is not enabled for your wiki. Unless you are using the wiki in a local environment only, this is a major security risk. The easiest way to add SSL is via a reverse proxy, see <a href="https://otterwiki.com/Installation#reverse-proxy">the documentation</a>.',
+                severity: 'CRITICAL'
+            });
+        }
+
+        // CSP check: inspect the backend response headers instead of
+        // making a separate HEAD request (which would hit /-/housekeeping
+        // and cause "Unknown task" toasts)
+        if (backendResponse) {
+            var csp = backendResponse.headers.get('Content-Security-Policy');
+            if (!csp) {
+                results.push({
+                    issue: 'CSP header missing',
+                    description: 'The Content Security Policy header is not set, which means resources could be loaded from any origin. This makes the wiki more vulnerable to cross-site scripting attacks. <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP">Learn more about CSP</a>.',
+                    severity: 'LOW'
+                });
+            }
+        }
+
+        return results;
+    }
+
+    // Main entry point
+    otterwiki.run_security_check = function() {
+        var btn = document.getElementById('security-check-btn');
+        var errorDiv = document.getElementById('security-check-error');
+        errorDiv.style.display = 'none';
+
+        btn.disabled = true;
+        btn.textContent = 'Running security check\u2026';
+
+        // Run backend checks and also use the response for CSP header check
+        fetch('/-/housekeeping/security-check', {
+            method: 'GET',
+            credentials: 'same-origin'
+        }).then(function(response) {
+            if (!response.ok) throw new Error('Backend check failed');
+            // Run frontend checks using this response for header inspection
+            var frontendResults = runFrontendChecks(response);
+            return response.json().then(function(data) {
+                var backendResults = data.results || [];
+                return backendResults.concat(frontendResults);
+            });
+        }).then(function(allResults) {
+            renderResults(allResults);
+        }).catch(function(err) {
+            console.error('Security check error:', err);
+            errorDiv.style.display = '';
+        }).finally(function() {
+            btn.disabled = false;
+            btn.textContent = 'Perform security check';
+        });
+    };
+})();
+</script>
 {% endblock js %}

--- a/otterwiki/templates/tools/housekeeping.html
+++ b/otterwiki/templates/tools/housekeeping.html
@@ -111,10 +111,9 @@
 <div id="security-check-error" style="display:none;">
 <p class="text-danger"><em>An error occurred while running the security check.</em></p>
 </div>
-<div id="security-check-passed-wrapper" class="mt-10" style="display:none;">
-    <button class="btn btn-secondary btn-sm" id="security-check-passed-toggle" type="button" onclick="otterwiki.toggle_security_check_passed()">Show passed checks (<span id="security-check-passed-count">0</span>)</button>
-    <div id="security-check-passed" style="display:none;" class="mt-10">
-    <table class="table compact" style="table-layout: fixed; width: 100%;">
+<details id="security-check-passed-wrapper" class="mt-10" style="display:none;">
+    <summary>Passed checks (<span id="security-check-passed-count">0</span>)</summary>
+    <table class="table compact mt-10" style="table-layout: fixed; width: 100%;">
         <thead>
             <tr>
                 <th style="width: 200px;"><strong>Check</strong></th>
@@ -124,8 +123,7 @@
         <tbody id="security-check-passed-tbody">
         </tbody>
     </table>
-    </div>
-</div>
+</details>
 <div class="mt-10">
     <button class="btn btn-primary" id="security-check-btn" onclick="otterwiki.run_security_check()">Perform security check</button>
 </div>
@@ -194,13 +192,10 @@
         var wrapper = document.getElementById('security-check-passed-wrapper');
         var tbody = document.getElementById('security-check-passed-tbody');
         var countSpan = document.getElementById('security-check-passed-count');
-        var panel = document.getElementById('security-check-passed');
-        var toggle = document.getElementById('security-check-passed-toggle');
 
         tbody.innerHTML = '';
         // collapse on each new run
-        panel.style.display = 'none';
-        toggle.textContent = '';
+        wrapper.open = false;
 
         if (passed.length === 0) {
             wrapper.style.display = 'none';
@@ -209,9 +204,6 @@
 
         wrapper.style.display = '';
         countSpan.textContent = passed.length;
-        toggle.appendChild(document.createTextNode('Show passed checks ('));
-        toggle.appendChild(countSpan);
-        toggle.appendChild(document.createTextNode(')'));
 
         for (var i = 0; i < passed.length; i++) {
             var r = passed[i];
@@ -222,18 +214,6 @@
             tbody.appendChild(tr);
         }
     }
-
-    otterwiki.toggle_security_check_passed = function() {
-        var panel = document.getElementById('security-check-passed');
-        var toggle = document.getElementById('security-check-passed-toggle');
-        var countSpan = document.getElementById('security-check-passed-count');
-        var visible = panel.style.display !== 'none';
-        panel.style.display = visible ? 'none' : '';
-        toggle.textContent = '';
-        toggle.appendChild(document.createTextNode((visible ? 'Show' : 'Hide') + ' passed checks ('));
-        toggle.appendChild(countSpan);
-        toggle.appendChild(document.createTextNode(')'));
-    };
 
     // Frontend security checks (runs alongside backend checks).
     // Returns {issues: [...], passed: [...]}.

--- a/otterwiki/views.py
+++ b/otterwiki/views.py
@@ -210,6 +210,15 @@ def housekeeping():
         return otterwiki.tools.handle_housekeeping(request.form)
 
 
+@app.route("/-/housekeeping/security-check", methods=["GET"])
+@login_required
+def security_check():
+    from otterwiki.security_check import run_backend_checks
+
+    results = run_backend_checks()
+    return jsonify(results=results)
+
+
 @app.route(
     "/-/admin/user_management", methods=["POST", "GET"]
 )  # pyright: ignore -- false positive

--- a/otterwiki/views.py
+++ b/otterwiki/views.py
@@ -219,8 +219,7 @@ def security_check():
     if not has_permission("ADMIN"):
         abort(403)
 
-    results = run_backend_checks()
-    return jsonify(results=results)
+    return jsonify(run_backend_checks())
 
 
 @app.route(

--- a/otterwiki/views.py
+++ b/otterwiki/views.py
@@ -213,7 +213,11 @@ def housekeeping():
 @app.route("/-/housekeeping/security-check", methods=["GET"])
 @login_required
 def security_check():
+    from otterwiki.auth import has_permission
     from otterwiki.security_check import run_backend_checks
+
+    if not has_permission("ADMIN"):
+        abort(403)
 
     results = run_backend_checks()
     return jsonify(results=results)

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -595,12 +595,14 @@ class TestHousekeepingSecurityCheck:
     def test_security_check_endpoint_returns_json(
         self, app_with_user, admin_client
     ):
-        """Test that the security check endpoint returns valid JSON with results."""
+        """Test that the security check endpoint returns valid JSON with issues and passed lists."""
         rv = admin_client.get("/-/housekeeping/security-check")
         assert rv.status_code == 200
         data = json.loads(rv.data)
-        assert "results" in data
-        assert isinstance(data["results"], list)
+        assert "issues" in data
+        assert "passed" in data
+        assert isinstance(data["issues"], list)
+        assert isinstance(data["passed"], list)
 
     def test_security_check_results_have_expected_fields(
         self, app_with_user, admin_client
@@ -609,17 +611,22 @@ class TestHousekeepingSecurityCheck:
         rv = admin_client.get("/-/housekeeping/security-check")
         assert rv.status_code == 200
         data = json.loads(rv.data)
-        for result in data["results"]:
-            assert "issue" in result
-            assert "description" in result
-            assert "severity" in result
-            assert result["severity"] in [
+        for issue in data["issues"]:
+            assert "issue" in issue
+            assert "description" in issue
+            assert issue.get("passed") is False
+            assert "severity" in issue
+            assert issue["severity"] in [
                 "NOTICE",
                 "LOW",
                 "MEDIUM",
                 "HIGH",
                 "CRITICAL",
             ]
+        for ok in data["passed"]:
+            assert "issue" in ok
+            assert "description" in ok
+            assert ok.get("passed") is True
 
     def test_security_check_requires_login(self, app_with_user, test_client):
         """Test that the security check endpoint requires authentication."""
@@ -628,6 +635,11 @@ class TestHousekeepingSecurityCheck:
         )
         assert rv.status_code == 302
         assert "/-/login" in rv.headers.get("Location", "")
+
+    def test_security_check_requires_admin(self, app_with_user, other_client):
+        """Test that non-admin users get 403 from the security check endpoint."""
+        rv = other_client.get("/-/housekeeping/security-check")
+        assert rv.status_code == 403
 
     def test_housekeeping_page_contains_security_check_section(
         self, app_with_user, admin_client
@@ -640,15 +652,25 @@ class TestHousekeepingSecurityCheck:
         assert "Perform security check" in html
         assert "security-check-btn" in html
 
+    def test_housekeeping_page_hides_security_check_for_non_admin(
+        self, app_with_user, other_client
+    ):
+        """Non-admin users should not see the security check panel."""
+        rv = other_client.get("/-/housekeeping")
+        assert rv.status_code == 200
+        html = rv.data.decode()
+        assert "security-check-btn" not in html
+
     def test_backend_checks_runnable(self, app_with_user, req_ctx):
         """Test that backend security checks can be run directly."""
         from otterwiki.security_check import run_backend_checks
 
         results = run_backend_checks()
-        assert isinstance(results, list)
+        assert isinstance(results, dict)
+        assert "issues" in results and "passed" in results
         # In test config, we expect at least some findings
         # (e.g., SERVER_NAME not set, anonymous write access)
-        assert len(results) > 0
+        assert len(results["issues"]) > 0
 
 
 class TestHousekeepingGeneral:

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # vim: set et ts=8 sts=4 sw=4 ai:
 
+import json
 import pytest
 
 
@@ -586,6 +587,68 @@ Link to [[Parent Sub/Child Sub]] and [[Parent Sub/Missing Sub]].
         html = rv.data.decode()
 
         assert "Missing" in html or "../Missing" in html
+
+
+class TestHousekeepingSecurityCheck:
+    """Tests for the security check functionality."""
+
+    def test_security_check_endpoint_returns_json(
+        self, app_with_user, admin_client
+    ):
+        """Test that the security check endpoint returns valid JSON with results."""
+        rv = admin_client.get("/-/housekeeping/security-check")
+        assert rv.status_code == 200
+        data = json.loads(rv.data)
+        assert "results" in data
+        assert isinstance(data["results"], list)
+
+    def test_security_check_results_have_expected_fields(
+        self, app_with_user, admin_client
+    ):
+        """Test that each security check result has the required fields."""
+        rv = admin_client.get("/-/housekeeping/security-check")
+        assert rv.status_code == 200
+        data = json.loads(rv.data)
+        for result in data["results"]:
+            assert "issue" in result
+            assert "description" in result
+            assert "severity" in result
+            assert result["severity"] in [
+                "NOTICE",
+                "LOW",
+                "MEDIUM",
+                "HIGH",
+                "CRITICAL",
+            ]
+
+    def test_security_check_requires_login(self, app_with_user, test_client):
+        """Test that the security check endpoint requires authentication."""
+        rv = test_client.get(
+            "/-/housekeeping/security-check", follow_redirects=False
+        )
+        assert rv.status_code == 302
+        assert "/-/login" in rv.headers.get("Location", "")
+
+    def test_housekeeping_page_contains_security_check_section(
+        self, app_with_user, admin_client
+    ):
+        """Test that the housekeeping page includes the security check UI."""
+        rv = admin_client.get("/-/housekeeping")
+        assert rv.status_code == 200
+        html = rv.data.decode()
+        assert "Security Check" in html
+        assert "Perform security check" in html
+        assert "security-check-btn" in html
+
+    def test_backend_checks_runnable(self, app_with_user, req_ctx):
+        """Test that backend security checks can be run directly."""
+        from otterwiki.security_check import run_backend_checks
+
+        results = run_backend_checks()
+        assert isinstance(results, list)
+        # In test config, we expect at least some findings
+        # (e.g., SERVER_NAME not set, anonymous write access)
+        assert len(results) > 0
 
 
 class TestHousekeepingGeneral:


### PR DESCRIPTION
Added a security check section for Housekeeping.

Implemented checks:
- Anonymous users can edit the wiki
- Anonymous users can upload files
- Server name not set
- CSP header missing
- HTTPS not enabled
- Fully open registrations
- Plugins are being used
- Custom HTML/CSS/JS is being used
- Custom HTML tags/attrs whitelist
- Missing of misconfigured reverse proxy

Most of the checks are performed on the backend side with a couple running on the frontend instead since we need to see the situation from the outside. Backend checks are solidly organized and easily extensible I think, while the frontend ones are a bit hacky, so if someone has any better ideas please share (not a blocker, though - could be improved later).