### PR TITLE
Forward onto wiki page after authenticating

### DIFF
--- a/otterwiki/pageindex.py
+++ b/otterwiki/pageindex.py
@@ -9,6 +9,7 @@ from flask import (
     abort,
     redirect,
     render_template,
+    request,
     url_for,
 )
 
@@ -219,7 +220,7 @@ class PageIndex:
     def render(self):
         if not has_permission("READ"):
             if not current_user.is_authenticated:
-                return redirect(url_for("login"))
+                return redirect(url_for("login", next=request.full_path))
             abort(403)
         menutree = SidebarPageIndex(self.path)
 

--- a/otterwiki/wiki.py
+++ b/otterwiki/wiki.py
@@ -512,7 +512,7 @@ class Page:
                 toast(
                     "You lack the permissions to access this wiki. Please login."
                 )
-            return redirect(url_for("login"))
+            return redirect(url_for("login", next="/"+self.pagename_full))
         # handle case that page doesn't exists
         self.exists_or_404()
 

--- a/otterwiki/wiki.py
+++ b/otterwiki/wiki.py
@@ -19,6 +19,7 @@ from flask import (
     make_response,
     redirect,
     render_template,
+    request,
     send_file,
     url_for,
 )
@@ -512,7 +513,7 @@ class Page:
                 toast(
                     "You lack the permissions to access this wiki. Please login."
                 )
-            return redirect(url_for("login", next="/"+self.pagename_full))
+            return redirect(url_for("login", next=request.full_path))
         # handle case that page doesn't exists
         self.exists_or_404()
 

--- a/otterwiki/wiki.py
+++ b/otterwiki/wiki.py
@@ -109,7 +109,7 @@ class Changelog:
     def render(self):
         if not has_permission("READ"):
             if not current_user.is_authenticated:
-                return redirect(url_for("login"))
+                return redirect(url_for("login", next=request.full_path))
             abort(403)
         log = self.get()
         pages = []
@@ -234,7 +234,7 @@ class Changelog:
     def show_commit(self, revision):
         if not has_permission("READ"):
             if not current_user.is_authenticated:
-                return redirect(url_for("login"))
+                return redirect(url_for("login", next=request.full_path))
             abort(403)
         try:
             metadata, diff = storage.show_commit(revision)
@@ -460,7 +460,7 @@ class Page:
         # handle permissions
         if not has_permission("READ"):
             if not current_user.is_authenticated:
-                return redirect(url_for("login"))
+                return redirect(url_for("login", next=request.full_path))
             abort(403)
         # handle case that the page doesn't exists
         if self.storage_error is not None:
@@ -841,7 +841,7 @@ class Page:
     def blame(self):
         if not has_permission("READ"):
             if not current_user.is_authenticated:
-                return redirect(url_for("login"))
+                return redirect(url_for("login", next=request.full_path))
             abort(403)
         # handle case that the page doesn't exists
         if self.storage_error is not None:
@@ -907,7 +907,7 @@ class Page:
     def diff(self, rev_a=None, rev_b=None):
         if not has_permission("READ"):
             if not current_user.is_authenticated:
-                return redirect(url_for("login"))
+                return redirect(url_for("login", next=request.full_path))
             abort(403)
         # handle case that the page doesn't exists
         self.exists_or_404()
@@ -938,7 +938,7 @@ class Page:
     def history(self, rev_a: str | None = None, rev_b: str | None = None):
         if not has_permission("READ"):
             if not current_user.is_authenticated:
-                return redirect(url_for("login"))
+                return redirect(url_for("login", next=request.full_path))
             abort(403)
 
         self.exists_or_404(in_git=True)
@@ -1145,7 +1145,7 @@ class Page:
     def render_attachments(self):
         if not has_permission("READ"):
             if not current_user.is_authenticated:
-                return redirect(url_for("login"))
+                return redirect(url_for("login", next=request.full_path))
             abort(403)
         # handle case that the page doesn't exists
         self.exists_or_404()
@@ -1230,7 +1230,7 @@ class Page:
     ):
         if not has_permission("READ"):
             if not current_user.is_authenticated:
-                return redirect(url_for("login"))
+                return redirect(url_for("login", next=request.full_path))
             abort(403)
         a = Attachment(self.pagepath, filename)
         if not a.exists():
@@ -1457,7 +1457,7 @@ class Attachment:
     def edit(self):
         if not has_permission("READ"):
             if not current_user.is_authenticated:
-                return redirect(url_for("login"))
+                return redirect(url_for("login", next=request.full_path))
             abort(403)
         if not self.exists():
             return abort(404)
@@ -1482,7 +1482,7 @@ class Attachment:
     def get(self):
         if not has_permission("READ"):
             if not current_user.is_authenticated:
-                return redirect(url_for("login"))
+                return redirect(url_for("login", next=request.full_path))
             abort(403)
         if self.revision is None:
             if not storage.exists(self.filepath):
@@ -1786,7 +1786,7 @@ class Search:
     def render(self):
         if not has_permission("READ"):
             if not current_user.is_authenticated:
-                return redirect(url_for("login"))
+                return redirect(url_for("login", next=request.full_path))
             abort(403)
         self.compile()
         result = self.search()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -228,6 +228,41 @@ def test_page_view_permissions(app_with_permissions, test_client):
     assert rv.status_code == 200
 
 
+def test_page_view_login_next_redirect(app_with_permissions, test_client):
+    # READ_ACCESS=REGISTERED: anonymous request to a page must redirect to
+    # login with a ?next= pointing back to that page, and logging in must
+    # forward the user back there.
+    app_with_permissions.config["READ_ACCESS"] = "REGISTERED"
+    rv = test_client.get(url_for("view", path="Home"))
+    assert rv.status_code == 302
+    assert "/-/login" in rv.location
+    assert "next=" in rv.location
+    assert "Home" in rv.location
+    # login with the next parameter as the login form would submit it
+    rv = test_client.post(
+        "/-/login",
+        data={
+            "email": "mail@example.org",
+            "password": "password1234",
+            "next": "/Home",
+        },
+    )
+    assert rv.status_code == 302
+    assert rv.location.endswith("/Home")
+    # rejects external next as open-redirect protection
+    rv = test_client.get("/-/logout", follow_redirects=True)
+    rv = test_client.post(
+        "/-/login",
+        data={
+            "email": "mail@example.org",
+            "password": "password1234",
+            "next": "//evil.example.com/",
+        },
+    )
+    assert rv.status_code == 302
+    assert "evil.example.com" not in rv.location
+
+
 def test_page_blame_permissions(app_with_permissions, test_client):
     fun = "blame"
     app_with_permissions.config["READ_ACCESS"] = "ANONYMOUS"


### PR DESCRIPTION
If you go to a wiki page and aren't authenticated you get redirected to login.
But Login doesn't forward back to that wiki page from history like it does for settings and other static pages. 

This adds that functionality to these by putting in the Next parameter.
If the URL in Next isn't valid, then we're put back to the home page anyway.