### PR TITLE
fixes title of edit pages to show 'pagename - edit'

### DIFF
--- a/otterwiki/wiki.py
+++ b/otterwiki/wiki.py
@@ -776,6 +776,7 @@ class Page:
 
         return render_template(
             "editor.html",
+            title="{} - edit".format(self.pagename),
             pagename=self.pagename,
             pagepath=self.pagepath,
             content_editor=content,


### PR DESCRIPTION
This addresses the issue of edit pages showing the generic wiki name instead of a consistent name like
"pagename - edit"

Issue: https://github.com/redimp/otterwiki/issues/484