### PR TITLE
Fix: DataTable JavaScript serialization vulnerability in caption

### DIFF
--- a/otterwiki/renderer_embeddings.py
+++ b/otterwiki/renderer_embeddings.py
@@ -6,6 +6,7 @@ import fnmatch
 import io
 import re
 import urllib.parse
+import json
 
 from otterwiki.plugins import hookimpl, plugin_manager, EmbeddingArgs
 from bs4 import BeautifulSoup
@@ -354,8 +355,9 @@ Options specific to CSV:
                     jsoptions.append(f"{bool_option}: {value}")
             for str_option in self.str_options:
                 if options.get(str_option.lower(), None):
+                    val = mistune.escape(options.get(str_option.lower()))
                     jsoptions.append(
-                        f"{str_option}: \"{mistune.escape(options.get(str_option))}\""
+                        f"{str_option}: {json.dumps(val)}"
                     )
             for int_option in self.int_options:
                 if options.get(int_option.lower(), None):


### PR DESCRIPTION
This PR fixes the Table caption parsing vulnerability mentioned in #500. Specifically, if a user created a table with a malicious caption containing unescaped quotes or JavaScript payloads, the previous string formatting logic in otterwiki/formatter.py would inject it directly into the DataTables initialization script, allowing XSS. Using json.dumps() ensures the caption is safely serialized as a valid JavaScript string literal regardless of its contents.

Partially addresses #500.