### PR TITLE
fix: match anchored WikiLinks in referencingpages example

### DIFF
--- a/docs/plugin_examples/plugin_referencingpages/otterwiki_referencingpages.py
+++ b/docs/plugin_examples/plugin_referencingpages/otterwiki_referencingpages.py
@@ -99,8 +99,14 @@ class ReferencingPages:
 
             # Process each WikiLink
             for match in matches:
-                # Clean up the page name
-                target_page = match.strip()
+                # Clean up the page name: drop any #anchor and a leading
+                # slash so the target matches the page path used for lookup
+                # (e.g. [[Page#section]] and [[/Page]] both point to "Page").
+                target_page = match.split('#', 1)[0].strip().lstrip('/')
+
+                # Skip pure anchor links like [[#section]]
+                if not target_page:
+                    continue
 
                 # Normalize the page path (handle case sensitivity)
                 if not self.app.config.get("RETAIN_PAGE_NAME_CASE", False):

--- a/tests/test_plugin_referencingpages.py
+++ b/tests/test_plugin_referencingpages.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+"""Tests for the example plugin docs/plugin_examples/plugin_referencingpages.
+
+The plugin builds the "referenced by" backlink index shown in the right
+sidebar. This is a regression test for links that carry a #anchor or a
+leading slash, which previously were not matched against the page path.
+
+The example plugins live under docs/ and are not installed, so the plugin
+module is loaded by path. Importing it auto-registers an instance; that
+instance is removed again so each test controls registration explicitly.
+"""
+
+import importlib.util
+import os
+import sys
+
+DOCS_PLUGINS = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "docs", "plugin_examples")
+)
+
+
+def _get_plugin_manager():
+    return sys.modules["otterwiki.plugins"].plugin_manager
+
+
+def _load_example_plugin(subdir, filename, class_name):
+    path = os.path.join(DOCS_PLUGINS, subdir, filename)
+    spec = importlib.util.spec_from_file_location(filename[:-3], path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    pm = _get_plugin_manager()
+    for plugin in list(pm.get_plugins()):
+        if type(plugin).__name__ == class_name:
+            pm.unregister(plugin)
+    return getattr(module, class_name)
+
+
+def save_page(client, pagename, content, commit_message="create"):
+    rv = client.post(
+        "/{}/save".format(pagename),
+        data={"content": content, "commit": commit_message},
+        follow_redirects=True,
+    )
+    assert rv.status_code == 200
+
+
+def _build_plugin(create_app):
+    cls = _load_example_plugin(
+        "plugin_referencingpages",
+        "otterwiki_referencingpages.py",
+        "ReferencingPages",
+    )
+    from otterwiki.server import db
+
+    plugin = cls()
+    plugin.setup(app=create_app, db=db, storage=create_app.storage)
+    return plugin
+
+
+def test_indexes_anchored_and_plain_links(test_client, create_app):
+    save_page(test_client, "BacklinkTarget", "# Target")
+    save_page(test_client, "PlainReferrer", "See [[BacklinkTarget]]")
+    save_page(test_client, "AnchorReferrer", "See [[BacklinkTarget#hello]]")
+
+    plugin = _build_plugin(create_app)
+    html = plugin.template_html_sidebar_right_inject(page="BacklinkTarget")
+
+    assert html is not None
+    # the plain link was always found; the anchored link is the regression
+    assert "plainreferrer" in html.lower()
+    assert "anchorreferrer" in html.lower()
+
+
+def test_ignores_pure_anchor_links(test_client, create_app):
+    save_page(test_client, "SoloTarget", "# Target")
+    # a self/in-page anchor link must not crash or create a backlink
+    save_page(test_client, "SoloReferrer", "Jump [[#section]] only")
+
+    plugin = _build_plugin(create_app)
+    html = plugin.template_html_sidebar_right_inject(page="SoloTarget")
+
+    assert html is None


### PR DESCRIPTION
The `referencingpages` example plugin indexes WikiLink targets verbatim. A link that carries a `#anchor` (e.g. `[[Page#section]]`) or a leading slash was stored as `page#section`, which never matches the anchor-less page path used when looking up backlinks for the sidebar. The result: such backlinks are silently missing.

I hit this on a real page — a referrer linking via `[[Some/Page#hello]]` did not show up under "Referencing pages", while a plain `[[Some/Page]]` from another page did.

### Fix
Strip the `#anchor` and a leading slash before normalizing the target, and skip pure in-page anchor links like `[[#section]]`.

### Tests
Adds `tests/test_plugin_referencingpages.py`, which asserts that both an anchored and a plain referrer show up as backlinks (the anchored one fails without this fix), and that a pure `[[#section]]` link creates no backlink. (Heads-up: the example plugins didn't have tests yet, so this introduces a small importlib-based loader for the docs/ plugin — easy to drop if you'd rather keep them test-free.)