### PR TITLE
Page Index - Allow multiple sub-tree items to be unfolded

### DIFF
--- a/otterwiki/static/js/otterwiki.js
+++ b/otterwiki/static/js/otterwiki.js
@@ -1507,6 +1507,29 @@ window.addEventListener("keydown", function(event) {
 });
 
 
+document.addEventListener("DOMContentLoaded", () => {
+  if (document.body.dataset.pageIndexRetainUserExpandedNodes === 'False') return;
+
+  const detailsList = document.querySelectorAll("details");
+
+  detailsList.forEach((d, i) => {
+    const summary = d.querySelector("summary");
+    const link = summary?.querySelector("a");
+    const key = "otterwiki/summary/node" + (link?.pathname?.toLowerCase() || i);
+
+    // Restore state from sessionStorage
+    const saved = sessionStorage.getItem(key);
+    if (saved === "open") d.setAttribute("open", "");
+    if (saved === "closed") d.removeAttribute("open");
+
+    // Save state on toggle
+    d.addEventListener("toggle", () => {
+      sessionStorage.setItem(key, d.open ? "open" : "closed");
+    });
+  });
+});
+
+
 let sidebar_links = document.querySelectorAll('a.sidebar-link');
 let header_anchors = document.querySelectorAll('div.page > h1, div.page > h2, div.page > h3, div.page > h4, div.page > h5, div.page > h6');
 

--- a/otterwiki/templates/layout.html
+++ b/otterwiki/templates/layout.html
@@ -267,6 +267,8 @@
 {#
     Flashes
 #}
+<body data-page-index-retain-user-expanded-nodes="{{config.SIDEBAR_MENUTREE_FOCUS == 'TOP'}}">
+
 <script type="text/javascript">
 {% with messages = get_flashed_messages(with_categories=true) %}
   {%- for category, message in messages %}


### PR DESCRIPTION
With `Page Index Focus` set to `TOP`, this change allows multiple sub-tree items to be manually unfolded by the user.