### PR TITLE
enhance referencing pages plugin

### DIFF
--- a/docs/plugin_examples/plugin_referencingpages/otterwiki_referencingpages.py
+++ b/docs/plugin_examples/plugin_referencingpages/otterwiki_referencingpages.py
@@ -104,7 +104,8 @@ class ReferencingPages:
             # Process each WikiLink
             for match in matches:
                 # Clean up the page name
-                target_page = match.strip()
+                target_page = urllib.parse.unquote(match.strip())
+                target_page = target_page.split("#", 1)[0].strip()
 
                 # Normalize the page path (handle case sensitivity)
                 if not self.app.config.get("RETAIN_PAGE_NAME_CASE", False):

--- a/docs/plugin_examples/plugin_referencingpages/otterwiki_referencingpages.py
+++ b/docs/plugin_examples/plugin_referencingpages/otterwiki_referencingpages.py
@@ -90,9 +90,9 @@ class ReferencingPages:
             # WikiLink patterns: [[Page Name]] or [[Page Name|Title]]
             # or:                [[Page Name]] or [[Title|Page Name]]
             wikilink_pattern = (
-                r'\[\[([^\]|]+)(?:\|[^\]]+)?\]\]'
+                r'\[\[(?!#)([^\]|]+)(?:\|[^\]]+)?\]\]'
                 if self.WIKILINK_STYLE.upper() == "LINKTITLE"
-                else r'\[\[(?:[^|\]]+\|)?([^\]]+)\]\]'
+                else r'\[\[(?![^|\]]*\|#)(?!#)(?:[^|\]]+\|)?([^\]]+)\]\]'
             )
             matches = re.findall(wikilink_pattern, content)
 
@@ -106,10 +106,6 @@ class ReferencingPages:
                 target_page = urllib.parse.unquote(match.strip())
                 target_page = target_page.split("#", 1)[0].strip()
                 target_page = self.normalize_page_name(target_page)
-
-                # Handle pure anchor links (e.g. #sub-section)
-                if not target_page:
-                    continue
 
                 # Skip self-references (a page cannot reference itself)
                 if target_page == source_page:

--- a/docs/plugin_examples/plugin_referencingpages/otterwiki_referencingpages.py
+++ b/docs/plugin_examples/plugin_referencingpages/otterwiki_referencingpages.py
@@ -3,17 +3,21 @@
 """
 Referencing Pages Plugin for An Otter Wiki
 
-This plugin demonstrates the template_html_sidebar_right_inject and repository_changed hooks.
+This plugin demonstrates:
+- template_html_sidebar_left_inject
+- template_html_sidebar_right_inject
+- repository_changed hooks
 
 Features:
 - Builds an in-memory index of page references (which pages link to which)
 - Updates the index when repository changes are detected
-- Displays a "This page is referenced by" block in the right sidebar
+- Displays a "Referencing pages" block in the sidebar
   showing pages that have WikiLinks pointing to the current page
 
 This plugin demonstrates:
 1. setup() - Initialize the plugin and build the initial reference index
 2. repository_changed() - Update the index when files change
+3. template_html_sidebar_left_inject() - Add content to the left sidebar
 3. template_html_sidebar_right_inject() - Add content to the right sidebar
 """
 
@@ -179,9 +183,22 @@ class ReferencingPages:
                 pass
 
     @hookimpl
+    def template_html_sidebar_left_inject(self, page):
+        """
+        Inject the "Referencing pages" block into the left sidebar.
+        """
+        return self.generate_sidebar_html(page, True)
+
+    @hookimpl
     def template_html_sidebar_right_inject(self, page):
         """
         Inject the "Referencing pages" block into the right sidebar.
+        """
+        return self.generate_sidebar_html(page, False)
+
+    def generate_sidebar_html(self, page, is_left_sidebar):
+        """
+        Generate the "Referencing pages" html block.
         """
         from otterwiki.helper import get_pagename
 
@@ -211,11 +228,12 @@ class ReferencingPages:
             )
             # Build the HTML for the sidebar block
             # Using the same structure as the "On this page" block
-            html = '''
-    <details class="collapse-panel" open>
-        <summary class="collapse-header">Referencing pages</summary>
+            html = f'''
+    <div id="extranav-toc" {' class="sidebar-toc d-xl-none"' if is_left_sidebar else ''}>
+        <details class="collapse-panel" open>
+            <summary class="collapse-header">Referencing pages</summary>
 
-        <div class="collapse-content">
+            <div class="collapse-content">
 '''
 
             # Add links to each referencing page, sorted by the displayed pagename
@@ -228,10 +246,11 @@ class ReferencingPages:
                 # URL encode the page path
                 url_path = urllib.parse.quote(pagename_full)
 
-                html += f'            <a href="/{url_path}" class="sidebar-link" title="{pagename_full}">{pagename}</a>\n'
+                html += f'                <a href="/{url_path}" class="sidebar-link sidebar-toc-1 sidebar-active" title="{pagename_full}">{pagename}</a>\n'
 
-            html += '''        </div>
-    </details>
+            html += '''            </div>
+        </details>
+    </div>
 '''
 
             return html

--- a/docs/plugin_examples/plugin_referencingpages/otterwiki_referencingpages.py
+++ b/docs/plugin_examples/plugin_referencingpages/otterwiki_referencingpages.py
@@ -96,20 +96,16 @@ class ReferencingPages:
             )
             matches = re.findall(wikilink_pattern, content)
 
-            # Get the source page path (remove .md extension)
-            source_page = (
-                filepath[:-3] if filepath.endswith('.md') else filepath
-            )
+            # Get the source page path
+            source_page = self.strip_filename_suffix(filepath)
+            source_page = self.normalise_page_name(source_page)
 
             # Process each WikiLink
             for match in matches:
                 # Clean up the page name
                 target_page = urllib.parse.unquote(match.strip())
                 target_page = target_page.split("#", 1)[0].strip()
-
-                # Normalize the page path (handle case sensitivity)
-                if not self.app.config.get("RETAIN_PAGE_NAME_CASE", False):
-                    target_page = target_page.lower()
+                target_page = self.normalise_page_name(target_page)
 
                 # Skip self-references (a page cannot reference itself)
                 if target_page == source_page:
@@ -135,7 +131,8 @@ class ReferencingPages:
         """
         Remove all references from a file from the index.
         """
-        source_page = filepath[:-3] if filepath.endswith('.md') else filepath
+        source_page = self.strip_filename_suffix(filepath)
+        source_page = self.normalise_page_name(source_page)
 
         # Remove this page from all reference lists
         for target_page in list(self.references.keys()):
@@ -210,11 +207,7 @@ class ReferencingPages:
                 return None
 
             # page is the pagepath string
-            page_path = page
-
-            # Normalize the page path
-            if not self.app.config.get("RETAIN_PAGE_NAME_CASE", False):
-                page_path = page_path.lower()
+            page_path = self.normalise_page_name(page)
 
             # Get the list of pages that reference this page
             referencing_pages = self.references.get(page_path, [])
@@ -222,7 +215,7 @@ class ReferencingPages:
             if not referencing_pages:
                 return None
 
-            # Puzzle into a dictionary, makes the references uniq and better printable.
+            # Puzzle into a dictionary, makes the references unique and better printable.
             referencing_pages = dict(
                 (k, [get_pagename(k), get_pagename(k, full=True)])
                 for k in referencing_pages
@@ -230,7 +223,7 @@ class ReferencingPages:
             # Build the HTML for the sidebar block
             # Using the same structure as the "On this page" block
             html = f'''
-    <div id="extranav-toc" {' class="sidebar-toc d-xl-none"' if is_left_sidebar else ''}>
+    <div id="backlinks-toc" {' class="sidebar-toc d-xl-none"' if is_left_sidebar else ''}>
         <details class="collapse-panel" open>
             <summary class="collapse-header">Referencing pages</summary>
 
@@ -247,7 +240,7 @@ class ReferencingPages:
                 # URL encode the page path
                 url_path = urllib.parse.quote(pagename_full)
 
-                html += f'                <a href="/{url_path}" class="sidebar-link sidebar-toc-1 sidebar-active" title="{pagename_full}">{pagename}</a>\n'
+                html += f'                <a href="/{url_path}" class="sidebar-link sidebar-toc-1" title="{pagename_full}">{pagename}</a>\n'
 
             html += '''            </div>
         </details>
@@ -265,6 +258,16 @@ class ReferencingPages:
             except:
                 pass
             return None
+
+    def normalise_page_name(self, page_name):
+        # Normalise the page name (handle case sensitivity)
+        if self.app.config.get("RETAIN_PAGE_NAME_CASE", False):
+            return page_name
+        return page_name.lower()
+
+    def strip_filename_suffix(self, filepath):
+        # Return the page path (remove .md extension)
+        return filepath[:-3] if filepath.endswith('.md') else filepath
 
 
 plugin_manager.register(ReferencingPages())

--- a/docs/plugin_examples/plugin_referencingpages/otterwiki_referencingpages.py
+++ b/docs/plugin_examples/plugin_referencingpages/otterwiki_referencingpages.py
@@ -98,14 +98,14 @@ class ReferencingPages:
 
             # Get the source page path
             source_page = self.strip_filename_suffix(filepath)
-            source_page = self.normalise_page_name(source_page)
+            source_page = self.normalize_page_name(source_page)
 
             # Process each WikiLink
             for match in matches:
                 # Clean up the page name
                 target_page = urllib.parse.unquote(match.strip())
                 target_page = target_page.split("#", 1)[0].strip()
-                target_page = self.normalise_page_name(target_page)
+                target_page = self.normalize_page_name(target_page)
 
                 # Handle pure anchor links (e.g. #sub-section)
                 if not target_page:
@@ -136,7 +136,7 @@ class ReferencingPages:
         Remove all references from a file from the index.
         """
         source_page = self.strip_filename_suffix(filepath)
-        source_page = self.normalise_page_name(source_page)
+        source_page = self.normalize_page_name(source_page)
 
         # Remove this page from all reference lists
         for target_page in list(self.references.keys()):
@@ -211,7 +211,7 @@ class ReferencingPages:
                 return None
 
             # page is the pagepath string
-            page_path = self.normalise_page_name(page)
+            page_path = self.normalize_page_name(page)
 
             # Get the list of pages that reference this page
             referencing_pages = self.references.get(page_path, [])
@@ -263,8 +263,8 @@ class ReferencingPages:
                 pass
             return None
 
-    def normalise_page_name(self, page_name):
-        # Normalise the page name (handle case sensitivity)
+    def normalize_page_name(self, page_name):
+        # Normalize the page name (handle case sensitivity)
         if self.app.config.get("RETAIN_PAGE_NAME_CASE", False):
             return page_name
         return page_name.lower()

--- a/docs/plugin_examples/plugin_referencingpages/otterwiki_referencingpages.py
+++ b/docs/plugin_examples/plugin_referencingpages/otterwiki_referencingpages.py
@@ -17,8 +17,8 @@ Features:
 This plugin demonstrates:
 1. setup() - Initialize the plugin and build the initial reference index
 2. repository_changed() - Update the index when files change
-3. template_html_sidebar_left_inject() - Add content to the left sidebar
 3. template_html_sidebar_right_inject() - Add content to the right sidebar
+4. template_html_sidebar_left_inject() - Add content to the left sidebar
 """
 
 import os
@@ -106,6 +106,9 @@ class ReferencingPages:
                 target_page = urllib.parse.unquote(match.strip())
                 target_page = target_page.split("#", 1)[0].strip()
                 target_page = self.normalize_page_name(target_page)
+
+                if not target_page:
+                    continue
 
                 # Skip self-references (a page cannot reference itself)
                 if target_page == source_page:
@@ -223,7 +226,7 @@ class ReferencingPages:
             # Build the HTML for the sidebar block
             # Using the same structure as the "On this page" block
             html = f'''
-    <div id="backlinks-toc" {' class="sidebar-toc d-xl-none"' if is_left_sidebar else ''}>
+    <div id="backlinks-toc-{'left' if is_left_sidebar else 'right'}" {' class="sidebar-toc d-xl-none"' if is_left_sidebar else ''}>
         <details class="collapse-panel" open>
             <summary class="collapse-header">Referencing pages</summary>
 

--- a/docs/plugin_examples/plugin_referencingpages/otterwiki_referencingpages.py
+++ b/docs/plugin_examples/plugin_referencingpages/otterwiki_referencingpages.py
@@ -107,6 +107,10 @@ class ReferencingPages:
                 target_page = target_page.split("#", 1)[0].strip()
                 target_page = self.normalise_page_name(target_page)
 
+                # Handle pure anchor links (e.g. #sub-section)
+                if not target_page:
+                    continue
+
                 # Skip self-references (a page cannot reference itself)
                 if target_page == source_page:
                     continue


### PR DESCRIPTION
This change enhances the referencing pages plugin, in three ways:

1. fix alignment of the page link (see the BEFORE screenshot below)
2. when displaying on a narrow screen, the 'referencing pages' disappears - the fix is to snap it to the left sidebar in the same way as 'on this page'
3. works for _anchor links_ to the current page

<img width="202" height="215" alt="image" src="https://github.com/user-attachments/assets/82073a68-eac0-488b-9af5-84f1ded9c3ab" />