### PR TITLE
Extend Page Index Title

### DIFF
--- a/otterwiki/pageindex.py
+++ b/otterwiki/pageindex.py
@@ -72,6 +72,11 @@ class PageIndex:
         else:
             self.path, self.breadcrumbs = None, None
             self.index_depth = 0
+        self.pagename = (
+            get_pagename_for_title(filepath=self.path)
+            if self.path is not None
+            else None
+        )
 
         t_start = timer()
         # get all files in the storage
@@ -228,7 +233,7 @@ class PageIndex:
         if self.path is None or self.path.rstrip("/") == "":
             title = "Page Index"
         else:
-            title = f"Page Index: /{self.path}"
+            title = f"Page Index - {self.pagename}"
 
         upsert_pagecrumbs(get_pagename(self.path or "/", full=True))
         return render_template(

--- a/otterwiki/templates/pageindex.html
+++ b/otterwiki/templates/pageindex.html
@@ -12,10 +12,16 @@
 {% endblock %}
 {% block body_attrs %}data-index-path="{{ pagepath | slugify(keep_slashes=True) }}"{% endblock %}
 {% block content %}
-<h2 class="pr-20 d-inline-block">Page Index</h2>
-<div class="d-inline-block custom-switch font-size-12 mb-10">
-  <input type="checkbox" id="switch-headings" value="" onchange="otterwiki.toggleClass(event.target.checked,'pagetoc')">
-  <label for="switch-headings">Toggle page headings</label>
+<div class="d-flex justify-content-between align-items-center mb-10">
+    <h2 class="mb-0">{{ title }}</h2>
+
+    <div class="custom-switch font-size-12">
+        <input
+            type="checkbox"
+            id="switch-headings"
+            onchange="otterwiki.toggleClass(event.target.checked,'pagetoc')">
+        <label for="switch-headings" class="mb-0">Toggle page headings</label>
+    </div>
 </div>
 <div style="">
 {% with hide_toc=True %}


### PR DESCRIPTION
Extend the Title on the Page Index page **from this**:

<img width="1030" height="443" alt="image" src="https://github.com/user-attachments/assets/bea3abf7-6a8b-498e-b5cc-bf40c957053e" />

**to this**:

<img width="1012" height="394" alt="image" src="https://github.com/user-attachments/assets/1f08ba53-ebec-492f-93df-51356fe5af4d" />
