### PR TITLE
Fix content display issues with page index

### DIFF
--- a/otterwiki/pageindex.py
+++ b/otterwiki/pageindex.py
@@ -89,10 +89,7 @@ class PageIndex:
         # filter .md files
         md_files = [f for f in files if f.endswith(".md")]
         for fn in md_files:
-            if self.path is None:
-                f = fn
-            else:
-                f = os.path.join(self.path, fn)
+            f = os.path.join(self.path or "", fn)
             page_depth = len(split_path(f)) - 1
             firstletter = get_pagename_for_title(fn, full=True)[0].upper()
             if firstletter not in self.toc.keys():
@@ -101,25 +98,21 @@ class PageIndex:
             subdirectories = split_path(fn)[:-1]
             for subdir_depth in range(len(subdirectories)):
                 subdir_path = join_path(subdirectories[0 : subdir_depth + 1])
-                if self.path is None:
-                    subdir_path_full = subdir_path
-                else:
-                    subdir_path_full = join_path([self.path, subdir_path])
+                subdir_path_full = join_path([self.path or "", subdir_path])
                 if storage.exists(
                     get_filename(
-                        subdir_path,
+                        subdir_path_full,
                     )
                 ):
                     # if page exists don't add the directory
                     continue
-                if subdir_path not in page_indices:
+                if subdir_path_full not in page_indices:
                     self.toc[firstletter].append(
                         PageIndexEntry(
                             depth=subdir_depth,
                             title=get_pagename_for_title(
                                 subdir_path, full=False
-                            )
-                            + "/",
+                            ),
                             url=url_for(
                                 "view",
                                 path=get_pagename(subdir_path_full, full=True),
@@ -128,7 +121,7 @@ class PageIndex:
                             has_children=True,
                         )
                     )
-                    page_indices.append(subdir_path)
+                    page_indices.append(subdir_path_full)
             pagetoc = []
             # default pagename is the pagename derived from the filename
             pagename = get_pagename(
@@ -169,15 +162,6 @@ class PageIndex:
                 full=False,
                 header=pagename,
             )
-            if self.path is not None:
-                # for nested pages, we need to strip the path prefix from the display name
-                full_display_name = get_pagename_for_title(
-                    f,
-                    full=True,
-                    header=pagename,
-                )
-                if full_display_name.lower().startswith(self.path.lower()):
-                    displayname = full_display_name[len(self.path) + 1 :]
             has_children = False
             for other in md_files:
                 if other.startswith(f[:-3] + "/"):

--- a/otterwiki/pageindex.py
+++ b/otterwiki/pageindex.py
@@ -50,7 +50,9 @@ class PageIndexEntry:
 class PageIndex:
     toc: dict[str, List[PageIndexEntry]] = {}
 
-    def __init__(self, path: str | None = None):
+    def __init__(
+        self, path: str | None = None, display_page_path: bool = False
+    ):
         '''
         This will generate an index of pages/toc of pages from a given path.
         '''
@@ -156,12 +158,16 @@ class PageIndex:
                             ),
                         )
                     )
-            # strip self.path from displayname and apply title formatting
+
             displayname = get_pagename_for_title(
                 f,
-                full=False,
+                full=display_page_path,
                 header=pagename,
             )
+            if self.path is not None and display_page_path:
+                if displayname.lower().startswith(self.path.lower()):
+                    displayname = displayname[len(self.path) + 1 :]
+
             has_children = False
             for other in md_files:
                 if other.startswith(f[:-3] + "/"):

--- a/otterwiki/renderer_embeddings.py
+++ b/otterwiki/renderer_embeddings.py
@@ -1196,7 +1196,7 @@ Options:
                 + '</ul></div>'
             )
 
-        togglediv = f"""<div class="d-inline-block custom-switch font-size-12 mb-10">
+        togglediv = f"""<div class="d-inline-block custom-switch font-size-12 mb-10" style="transform: translateY(-36px);float:right;">
     <input type="checkbox" id="switch-headings" {"checked" if show_toc else ""} value="" onchange="otterwiki.toggleClass(event.target.checked,'pagetoc')"><label for="switch-headings">Toggle page headings</label>
 </div>"""
 

--- a/otterwiki/renderer_embeddings.py
+++ b/otterwiki/renderer_embeddings.py
@@ -1163,7 +1163,7 @@ Options:
 
         page = getattr(self, 'page', None)
         path = page.pagepath if page else None
-        page_index = PageIndex(path=path)
+        page_index = PageIndex(path=path, display_page_path=style == 'list')
 
         pages = page_index.toc
         if src != '*':

--- a/otterwiki/templates/pageindex.html
+++ b/otterwiki/templates/pageindex.html
@@ -1,31 +1,31 @@
 {# vim: set et ts=8 sts=4 sw=4 ai: #}
 {% extends "wiki.html" %}
 {% block menu %}
-{{ super() }}
-{% include 'snippets/menu.html' %}
-{% include 'snippets/menutree.html' %}
+    {{ super() }}
+    {% include 'snippets/menu.html' %}
+    {% include 'snippets/menutree.html' %}
 {% endblock %}
 {% block navbardropdown %}
-{% include 'snippets/navbardropdown_rename_remove.html' %}
-                    <div class="dropdown-divider mt-5 mb-5"></div>
-{{ super() }}
+    {% include 'snippets/navbardropdown_rename_remove.html' %}
+    <div class="dropdown-divider mt-5 mb-5"></div>
+    {{ super() }}
 {% endblock %}
 {% block body_attrs %}data-index-path="{{ pagepath | slugify(keep_slashes=True) }}"{% endblock %}
 {% block content %}
-<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-10">
-    <h2 class="mb-0">{{ title }}</h2>
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-10">
+        <h2 class="mb-0">{{ title }}</h2>
 
-    <div class="custom-switch font-size-12">
-        <input
-            type="checkbox"
-            id="switch-headings"
-            onchange="otterwiki.toggleClass(event.target.checked,'pagetoc')">
-        <label for="switch-headings" class="mb-0">Toggle page headings</label>
+        <div class="custom-switch font-size-12">
+            <input
+                type="checkbox"
+                id="switch-headings"
+                onchange="otterwiki.toggleClass(event.target.checked,'pagetoc')">
+            <label for="switch-headings" class="mb-0">Toggle page headings</label>
+        </div>
     </div>
-</div>
-<div style="">
-{% with hide_toc=True %}
-{% include 'snippets/pageindex.html' %}
-{% endwith %}
-</div>
+    <div style="">
+    {% with hide_toc=True %}
+    {% include 'snippets/pageindex.html' %}
+    {% endwith %}
+    </div>
 {% endblock content %}


### PR DESCRIPTION
Fixes: #537 

Below is an example of the updated page index:

<img width="991" height="239" alt="image" src="https://github.com/user-attachments/assets/c0df9d54-e52b-4222-b0c0-1fd874105f68" />

See the items under the **"S"** heading.