### PR TITLE
Update Styling/Alignment on PageIndex Embedding

### DIFF
--- a/otterwiki/renderer_embeddings.py
+++ b/otterwiki/renderer_embeddings.py
@@ -1196,7 +1196,7 @@ Options:
                 + '</ul></div>'
             )
 
-        togglediv = f"""<div class="d-inline-block custom-switch font-size-12 mb-10" style="transform: translateY(-36px);float:right;">
+        togglediv = f"""<div class="d-inline-block custom-switch font-size-12 mb-10" style="transform: translateY(-44px);float:right;">
     <input type="checkbox" id="switch-headings" {"checked" if show_toc else ""} value="" onchange="otterwiki.toggleClass(event.target.checked,'pagetoc')"><label for="switch-headings">Toggle page headings</label>
 </div>"""
 

--- a/otterwiki/renderer_embeddings.py
+++ b/otterwiki/renderer_embeddings.py
@@ -1196,7 +1196,7 @@ Options:
                 + '</ul></div>'
             )
 
-        togglediv = f"""<div class="d-inline-block custom-switch font-size-12 mb-10" style="transform: translateY(-44px);float:right;">
+        togglediv = f"""<div class="d-inline-block custom-switch font-size-12 mb-10">
     <input type="checkbox" id="switch-headings" {"checked" if show_toc else ""} value="" onchange="otterwiki.toggleClass(event.target.checked,'pagetoc')"><label for="switch-headings">Toggle page headings</label>
 </div>"""
 

--- a/otterwiki/static/css/elements/page.css
+++ b/otterwiki/static/css/elements/page.css
@@ -11,6 +11,14 @@
 .page h5 { font-size: 2.0rem; }
 .page h6 { font-size: 1.6rem; }
 
+.page .pageindex-header {
+    font-size: var(--content-title-font-size);
+}
+
+.pageindex-embedding {
+    clear: right;
+}
+
 .page p,
 .page li {
     font-size: 1.6rem;

--- a/otterwiki/static/css/elements/page.css
+++ b/otterwiki/static/css/elements/page.css
@@ -11,14 +11,6 @@
 .page h5 { font-size: 2.0rem; }
 .page h6 { font-size: 1.6rem; }
 
-.page .pageindex-header {
-    font-size: var(--content-title-font-size);
-}
-
-.pageindex-embedding {
-    clear: right;
-}
-
 .page p,
 .page li {
     font-size: 1.6rem;
@@ -154,4 +146,36 @@
     border: 0;
     margin: 0;
     background-color: transparent;
+}
+
+.page .pageindex-header {
+    font-size: var(--content-title-font-size);
+}
+
+/* Embedded PageIndex: move heading toggle into the title row */
+.pageindex-embedding {
+    position: relative;
+}
+
+/* The toggle immediately before an embedded index */
+.pageindex-embedding:before {
+    content: "";
+    display: block;
+}
+
+/* Parent page title + toggle alignment */
+article.page > h1 + .custom-switch {
+    float: right;
+    margin-top: -4.4rem;
+    margin-bottom: 0;
+}
+
+/* Recover the vertical space used by the old toggle position */
+article.page > h1 + .custom-switch + .pageindex-embedding {
+    clear: both;
+    margin-top: -2.75rem;
+}
+
+article.page .pageindex-embedding {
+    padding-top: 0.1rem;
 }

--- a/otterwiki/static/css/elements/page.css
+++ b/otterwiki/static/css/elements/page.css
@@ -157,12 +157,6 @@
     position: relative;
 }
 
-/* The toggle immediately before an embedded index */
-.pageindex-embedding:before {
-    content: "";
-    display: block;
-}
-
 /* Parent page title + toggle alignment */
 article.page > h1 + .custom-switch {
     float: right;

--- a/otterwiki/templates/pageindex.html
+++ b/otterwiki/templates/pageindex.html
@@ -13,7 +13,7 @@
 {% block body_attrs %}data-index-path="{{ pagepath | slugify(keep_slashes=True) }}"{% endblock %}
 {% block content %}
     <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-10">
-        <h2 class="mb-0">{{ title }}</h2>
+        <h2 class="my-0">{{ title }}</h2>
 
         <div class="custom-switch font-size-12">
             <input


### PR DESCRIPTION
Fix styling and alignment on PageIndex embedding to match the standard page index.

**Standard Page Index Example**:

<img width="992" height="230" alt="image" src="https://github.com/user-attachments/assets/6b5eb267-c5ac-4f5c-8365-bcf694775dcb" />

**Page Index Embedding Example**:

<img width="992" height="304" alt="image" src="https://github.com/user-attachments/assets/12f7a966-acc6-48d7-8586-d63f45df4346" />

**Issues Fixed**:

1.  the single character column headings have a larger font than the standard page index
2. the columns do not extend to the full page width
3. the standard page index title displays slightly lower than a standard page title