### PR TITLE
Parse space and/or comma separated roles + tests

### DIFF
--- a/otterwiki/auth.py
+++ b/otterwiki/auth.py
@@ -646,7 +646,11 @@ class ProxyHeaderAuth:
 
     @staticmethod
     def _parse_roles(roles_str):
-        return {r.strip().upper() for r in roles_str.split(',') if r.strip()}
+        return {
+            r.strip().upper()
+            for r in re.split(r'[,\s]+', roles_str)
+            if r.strip()
+        }
 
     def _map_roles_to_permissions(self, header_roles):
         header_roles = set(header_roles)

--- a/tests/test_auth_proxy_header.py
+++ b/tests/test_auth_proxy_header.py
@@ -284,6 +284,9 @@ def test_parse_roles(create_app):
         ProxyHeaderAuth._parse_roles  # pyright: ignore[reportPrivateUsage]
     )
     assert parse_roles("moderator, admin") == {"MODERATOR", "ADMIN"}
+    assert parse_roles("moderator ,admin") == {"MODERATOR", "ADMIN"}
+    assert parse_roles("moderator admin") == {"MODERATOR", "ADMIN"}
+    assert parse_roles("moderator  admin") == {"MODERATOR", "ADMIN"}
     assert parse_roles(" admin ") == {"ADMIN"}
     assert parse_roles("a,,b, ,c") == {"A", "B", "C"}
     assert parse_roles("") == set()


### PR DESCRIPTION
In addition to comma separated roles, this change also allows space separated roles as this is being used by some authentication providers.

New functionality highlighted in green:
```diff
>>> _parse_roles("Admin,Dev,User")
{'ADMIN', 'DEV', 'USER'}
>>> _parse_roles("Admin, Dev, User")
{'ADMIN', 'DEV', 'USER'}
- >>> _parse_roles("Admin Dev User")
- {'ADMIN DEV USER'}
+ >>> _parse_roles("Admin Dev User")
+ {'ADMIN', 'DEV', 'USER'}
```

Tests have also been added and have been completed successfully. 