### PR TITLE
Fix inconsistencies in the readme, add Gateway API HTTPRoute support

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -4,7 +4,7 @@ name: otterwiki
 description: An Otter Wiki is a minimalstic wiki powered by python, markdown and git.
 home: https://otterwiki.com
 type: application
-version: 0.1.4
+version: 0.2.0
 appVersion: "2"
 icon: "https://github.com/redimp/otterwiki/blob/c805922fe886f724eefdd118ac0c1d444d59c8aa/otterwiki/static/img/otterhead.png"
 maintainers:

--- a/helm/README.md
+++ b/helm/README.md
@@ -46,6 +46,7 @@ that can be configured during installation.
 | `service.type`                    | Kubernetes Service type                              | `ClusterIP`                                 |
 | `service.port`                    | Service HTTP port                                    | `80`                                        |
 | `ingress.enabled`                 | Enable ingress controller resource                   | `false`                                     |
+| `ingress.annotations`             | Configure custom annotations to add to the resource  | `{}`                                        |
 | `ingress.hosts[0].host`           | Hostname to your OtterWiki installation              | `otterwiki.local`                           |
 | `ingress.hosts[0].paths.path`     | Path within the url structure                        | `/`                                         |
 | `ingress.hosts[0].paths.pathType` | Path matching rule                                   | `ImplementationSpecific`                    |
@@ -57,6 +58,7 @@ that can be configured during installation.
 | `httproute.parentRefs`            | References to the parent Gateway controller objects  | `[]`                                        |
 | `httproute.rules`                 | Rules to apply to the HTTPRoute object               | `[]`                                        |
 | `persistence.enabled`             | Enable persistence using PVC                         | `true`                                      |
+| `persistence.annotations`         | Configure custom annotations to add to the resource  | `{}`                                        |
 | `persistence.existingClaim`       | Use an existing PVC instead of creating one          | `nil`                                       |
 | `persistence.storageClass`        | PVC Storage Class for OtterWiki volume               | `nil` (uses alpha storage class annotation) |
 | `persistence.accessMode`          | PVC Access Mode for OtterWiki volume                 | `ReadWriteOnce`                             |

--- a/helm/README.md
+++ b/helm/README.md
@@ -14,7 +14,7 @@ If you run into any issues, please report them via [github](https://github.com/r
 
 - Kubernetes 1.23+
 - Helm 3.8.0+
-- PV provisioner support in the underlying infrastructure
+- PV provisioner support in the underlying infrastructure, or set `persistence.existingClaim`
 
 ## Installing the Chart
 
@@ -57,6 +57,7 @@ that can be configured during installation.
 | `httproute.parentRefs`            | References to the parent Gateway controller objects  | `[]`                                        |
 | `httproute.rules`                 | Rules to apply to the HTTPRoute object               | `[]`                                        |
 | `persistence.enabled`             | Enable persistence using PVC                         | `true`                                      |
+| `persistence.existingClaim`       | Use an existing PVC instead of creating one          | `nil`                                       |
 | `persistence.storageClass`        | PVC Storage Class for OtterWiki volume               | `nil` (uses alpha storage class annotation) |
 | `persistence.accessMode`          | PVC Access Mode for OtterWiki volume                 | `ReadWriteOnce`                             |
 | `persistence.size`                | PVC Storage Request for OtterWiki volume             | `512Mi`                                     |

--- a/helm/README.md
+++ b/helm/README.md
@@ -63,6 +63,7 @@ that can be configured during installation.
 | `persistence.storageClass`        | PVC Storage Class for OtterWiki volume               | `nil` (uses alpha storage class annotation) |
 | `persistence.accessMode`          | PVC Access Mode for OtterWiki volume                 | `ReadWriteOnce`                             |
 | `persistence.size`                | PVC Storage Request for OtterWiki volume             | `512Mi`                                     |
+| `persistence.subPath`             | Sub-path to use for OtterWiki's data within the PV   | `nil`                                       |
 | `resources`                       | CPU/Memory resource requests/limits                  | `{}`                                        |
 | `nodeSelector`                    | Node labels for pod assignment                       | `{}`                                        |
 | `affinity`                        | Affinity settings for pod assignment                 | `{}`                                        |

--- a/helm/README.md
+++ b/helm/README.md
@@ -68,6 +68,7 @@ that can be configured during installation.
 | `affinity`                        | Affinity settings for pod assignment                 | `{}`                                        |
 | `tolerations`                     | Toleration labels for pod assignment                 | `[]`                                        |
 | `podAnnotations`                  | Pod annotations                                      | `{}`                                        |
+| `podLabelsAdditional`             | Specify additional labels to add to the pods         | `{}`                                        |
 
 
 The parameters can be specified using `--set key=value[,key=value]` as argument to `helm install`, e.g.

--- a/helm/README.md
+++ b/helm/README.md
@@ -28,7 +28,7 @@ helm repo update
 After that, to install the chart with the release name `my-otterwiki`, run:
 
 ```bash
-helm install my-otterwiki --version 0.1.0 otterwiki/otterwiki
+helm install my-otterwiki --version 0.2.0 otterwiki/otterwiki
 ```
 
 The command deploys An Otter Wiki on the kubernetes cluster in the default namespace
@@ -51,6 +51,11 @@ that can be configured during installation.
 | `ingress.hosts[0].paths.pathType` | Path matching rule                                   | `ImplementationSpecific`                    |
 | `ingress.hosts[0].tls[0].hosts[0]`  |  Hostname for which TLS will be configured         | `otterwiki.local`                           |
 | `ingress.hosts[0].tls[0].secretName` | TLS Secret (certificates)                         | `otterwiki-local-tls`                       |
+| `httproute.enabled`               | Enable Gateway API HTTPRoute resource                | `false`                                     |
+| `httproute.annotations`           | Configure custom annotations to add to the resource  | `{}`                                        |
+| `httproute.hostnames`             | List of hostnames to your OtterWiki installation     | `[otterwiki.local]`                         |
+| `httproute.parentRefs`            | References to the parent Gateway controller objects  | `[]`                                        |
+| `httproute.rules`                 | Rules to apply to the HTTPRoute object               | `[]`                                        |
 | `persistence.enabled`             | Enable persistence using PVC                         | `true`                                      |
 | `persistence.storageClass`        | PVC Storage Class for OtterWiki volume               | `nil` (uses alpha storage class annotation) |
 | `persistence.accessMode`          | PVC Access Mode for OtterWiki volume                 | `ReadWriteOnce`                             |
@@ -69,7 +74,7 @@ helm install my-otterwiki \
   --set config.SITE_DESCRIPTION="An Otter Wiki deployed with Helm" \
   --set ingress.enabled=true \
   --set ingress.hosts[0].host="helm.otterwiki.com" \
-  --version 0.1.0 \
+  --version 0.2.0 \
   otterwiki/otterwiki
 ```
 
@@ -89,14 +94,14 @@ and deploy it with
 ```bash
 helm install my-otterwiki \
   --values values.yaml \
-  --version 0.1.0 \
+  --version 0.2.0 \
   otterwiki/otterwiki
 ```
 
 The most recent default `values.yaml` can be fetched using
 
 ```bash
-helm show values --version 0.1.0 otterwiki/otterwiki > values.yaml
+helm show values --version 0.2.0 otterwiki/otterwiki > values.yaml
 ```
 
 ### Application configuration

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -4,6 +4,13 @@ Open up your installation of An Otter Wiki via
 {{ range $host := .Values.ingress.hosts }}
     http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}
 {{- end }}
+{{- else if .Values.httproute.enabled }}
+
+Open up your installation of An Otter Wiki using one of the following URLs:
+{{ range $host := .Values.httproute.hostnames }}
+    http://{{ $host }} | https://{{ $host }}
+{{- end}}
+    NOTE: whether to use HTTP or HTTPS depends on your Gateway.
 {{- else if contains "NodePort" .Values.service.type }}
 
 Get the application URL by running these commands:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -23,7 +23,9 @@ spec:
       {{- end }}
       labels:
         {{- include "otterwiki.selectorLabels" . | nindent 8 }}
-        {{- toYaml .Values.podLabelsAdditional | nindent 8 }}
+        {{- with .Values.podLabelsAdditional }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       {{- end }}
       labels:
         {{- include "otterwiki.selectorLabels" . | nindent 8 }}
+        {{- toYaml .Values.podLabelsAdditional | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/templates/httproute.yaml
+++ b/helm/templates/httproute.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.httproute.enabled (semverCompare ">=1.25-0" .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1") -}}
+{{- $fullName := include "otterwiki.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "otterwiki.labels" . | nindent 4 }}
+  {{- with .Values.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  hostnames:
+    {{- toYaml .Values.httproute.hostnames | nindent 4 }}
+  parentRefs:
+    {{- toYaml .Values.httproute.parentRefs | nindent 4 }}
+  rules:
+  {{- range .Values.httproute.rules }}
+    - backendRefs:
+        - name: {{ $fulName }}
+          kind: Service
+          port: {{ $svcPort }}
+    {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/templates/httproute.yaml
+++ b/helm/templates/httproute.yaml
@@ -17,22 +17,29 @@ spec:
   parentRefs:
     {{- toYaml .Values.httproute.parentRefs | nindent 4 }}
   rules:
-  {{- range .Values.httproute.rules }}
+  {{- if gt (len .Values.httproute.rules) 0 }}
+    {{- range .Values.httproute.rules }}
     - backendRefs:
         - name: {{ $fullName }}
           kind: Service
           port: {{ $svcPort }}
-    {{- with .filters }}
+      {{- with .filters }}
       filters:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .matches }}
+      {{- end }}
+      {{- with .matches }}
       matches:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .timeouts }}
+      {{- end }}
+      {{- with .timeouts }}
       timeouts:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
+  {{- else }}
+    - backendRefs:
+        - name: {{ $fullName }}
+          kind: Service
+          port: {{ $svcPort }}
   {{- end }}
 {{- end }}

--- a/helm/templates/httproute.yaml
+++ b/helm/templates/httproute.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.httproute.enabled (semverCompare ">=1.25-0" .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1") -}}
+{{- if and .Values.httproute.enabled (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1") -}}
 {{- $fullName := include "otterwiki.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 apiVersion: gateway.networking.k8s.io/v1

--- a/helm/templates/httproute.yaml
+++ b/helm/templates/httproute.yaml
@@ -19,7 +19,7 @@ spec:
   rules:
   {{- range .Values.httproute.rules }}
     - backendRefs:
-        - name: {{ $fulName }}
+        - name: {{ $fullName }}
           kind: Service
           port: {{ $svcPort }}
     {{- with .filters }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -85,6 +85,9 @@ persistence:
   accessMode: ReadWriteOnce
   annotations: {}
   storageClass: ""
+  #existingClaim: name-of-existing-pvc
+  # To use an existing claim persistence.enabled must also be true.
+  # Other options are ignored.
 
 nodeSelector: {}
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -53,6 +53,8 @@ persistence:
   accessMode: ReadWriteOnce
   annotations: {}
   storageClass: ""
+  #subPath: path-within-volume
+  # sub-path to use for otterwiki's app-data volume
   #existingClaim: name-of-existing-pvc
   # To use an existing claim persistence.enabled must also be true.
   # Other options are ignored.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -24,6 +24,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 podAnnotations: {}
+podLabelsAdditional: {}
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -98,4 +98,6 @@ httproute:
   #   namespace: kube-system
   rules: []
   # See HTTPRoute.spec.rules API specification.
-  # Supported are filters, matches, and timeouts.
+  # Supported are filters, matches, and timeouts. Appropriate backendRefs are added automatically
+  # to each custom rule.
+  # Leaving this on default creates a default rule allowing access to OtterWiki.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,9 +1,14 @@
 # Default values for otterwiki.
+nameOverride: ""
+fullnameOverride: ""
+
 image:
   repository: redimp/otterwiki
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+
+imagePullSecrets: []
 
 ## Configure the otterwiki using this mapping. The configuration will be stored
 ## in a configMap or for those variables considered as secret in a Secret.
@@ -19,16 +24,6 @@ config: {}
 ## these will we stored in a configMap and the secrets in a Secret.
 env: {}
 
-imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
-
-podAnnotations: {}
-podLabelsAdditional: {}
-
-podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -36,6 +31,37 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
+
+podAnnotations: {}
+
+podLabelsAdditional: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+persistence:
+  enabled: true
+  size: 512Mi
+  accessMode: ReadWriteOnce
+  annotations: {}
+  storageClass: ""
+  #existingClaim: name-of-existing-pvc
+  # To use an existing claim persistence.enabled must also be true.
+  # Other options are ignored.
+
+affinity: {}
+
+nodeSelector: {}
+
+tolerations: []
 
 service:
   type: ClusterIP
@@ -71,27 +97,3 @@ httproute:
   rules: []
   # See HTTPRoute.spec.rules API specification.
   # Supported are filters, matches, and timeouts.
-
-resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-persistence:
-  enabled: true
-  size: 512Mi
-  accessMode: ReadWriteOnce
-  annotations: {}
-  storageClass: ""
-  #existingClaim: name-of-existing-pvc
-  # To use an existing claim persistence.enabled must also be true.
-  # Other options are ignored.
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -56,6 +56,21 @@ ingress:
   #    hosts:
   #      - otterwiki.local
 
+httproute:
+  enabled: false
+  annotations: {}
+  hostnames:
+    - otterwiki.local
+  parentRefs: []
+  # See HTTPRoute.spec.parentRefs API specification.
+  # - group: gateway.networking.k8s.io
+  #   kind: Gateway
+  #   name: your-gateway-name
+  #   namespace: kube-system
+  rules: []
+  # See HTTPRoute.spec.rules API specification.
+  # Supported are filters, matches, and timeouts.
+
 resources: {}
   # limits:
   #   cpu: 100m


### PR DESCRIPTION
The current version of the helm chart provided by _An Otter Wiki_ works well and provides most functionality that most users would require. For my specific use-case there are some things missing, that I would like to contribute. Apart from new functionality there are also some changes to the README  that fix inconsistencies and missing information.

# Proposed changes

**New functionality**
- Add support for GatewayAPI HTTPRoute configuration
- Add value to optionally configure labels to be added to pods
- Adds documentation for the new functionality in the README

**Fixes to the README**
- Mention the option of using `persistence.existingClaim` that was undocumented before, and add missing value table entry
- Add missing values table entries for:
  - `ingress.annotations`
  - `persistence.annotations`
  - `persistence.subPath`

**Common**
- Update the helm chart version to `0.2.0` due to the new functionality introduced.

# Tests

The chart has been successfully tested:
- using only "old" values, assuring the update does not break current installations
- with the new values incorporated, ensuring the new functionality actually works
- with the new default values provided with the chart