### PR TITLE
make container port separately configurable

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -60,6 +60,7 @@ that can be configured during installation.
 | `affinity`                        | Affinity settings for pod assignment                 | `{}`                                        |
 | `tolerations`                     | Toleration labels for pod assignment                 | `[]`                                        |
 | `podAnnotations`                  | Pod annotations                                      | `{}`                                        |
+| `podContainerPort`                | Port exposed by the container                        | `80`                                        |
 
 
 The parameters can be specified using `--set key=value[,key=value]` as argument to `helm install`, e.g.

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
               optional: true
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: {{ .Values.podContainerPort }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -23,6 +23,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+podContainerPort: 80 # 8080 if using the -slim image variant
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
If wanting to use a different Service port other than 80 (or 8080 in the `slim` case), the container port needs to be configured separately such that the health check can succeed and allow the Service to become functional.

This was the only way to get it working on my k3s but I'm not using any Ingresses or HTTPRoutes, so my case is likely a little different