### PR TITLE
Pass custom icon definitions via clean_html()

### DIFF
--- a/otterwiki/sidebar.py
+++ b/otterwiki/sidebar.py
@@ -10,6 +10,7 @@ from flask import url_for
 from otterwiki.plugins import call_hook
 from otterwiki.gitstorage import StorageError
 from otterwiki.server import storage, app
+from otterwiki.renderer import clean_html
 from otterwiki.util import (
     get_page_directoryname,
     split_path,
@@ -53,6 +54,10 @@ class SidebarMenu:
                 entry.get("icon", ""),
             )
             self.config.append({"link": link, "title": title, "icon": icon})
+
+            # The icon is rendered as raw HTML in snippets/menu.html, so it is
+            # sanitized with the same allowlist used for the markdown renderer.
+            icon = clean_html(icon)
 
             # handle separator
             if link == "---" and empty(title) and empty(icon):

--- a/otterwiki/sidebar.py
+++ b/otterwiki/sidebar.py
@@ -10,7 +10,7 @@ from flask import url_for
 from otterwiki.plugins import call_hook
 from otterwiki.gitstorage import StorageError
 from otterwiki.server import storage, app
-from otterwiki.renderer import clean_html
+from otterwiki.renderer import clean_html, parse_custom_allowlist
 from otterwiki.util import (
     get_page_directoryname,
     split_path,
@@ -40,6 +40,11 @@ class SidebarMenu:
                 f"Error decoding SIDEBAR_CUSTOM_MENU={app.config.get('SIDEBAR_CUSTOM_MENU','')}: {e}"
             )
             raw_config = []
+        # the icons are rendered as raw html in snippets/menu.html, so they
+        # are sanitized with the allowlist used for the markdown renderer
+        custom_tags, custom_attributes = parse_custom_allowlist(
+            app.config.get("RENDERER_HTML_ALLOWLIST", "")
+        )
         # generate both config and menu from raw_config
         for entry in raw_config:
             if (
@@ -55,9 +60,11 @@ class SidebarMenu:
             )
             self.config.append({"link": link, "title": title, "icon": icon})
 
-            # The icon is rendered as raw HTML in snippets/menu.html, so it is
-            # sanitized with the same allowlist used for the markdown renderer.
-            icon = clean_html(icon)
+            icon = clean_html(
+                icon,
+                custom_tags=custom_tags,
+                custom_attributes=custom_attributes,
+            )
 
             # handle separator
             if link == "---" and empty(title) and empty(icon):

--- a/tests/test_sidebar.py
+++ b/tests/test_sidebar.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # vim: set et ts=8 sts=4 sw=4 ai:
 
+import json
 import os
 
 from bs4 import BeautifulSoup
@@ -176,6 +177,83 @@ def test_sidebar_custom_menu_with_icons(create_app, test_client, req_ctx):
     assert menu_data["items"][0]["type"] == "link"
     assert '<i class="fas fa-home"></i>' in menu_data["items"][0]["html"]
     assert "Home Page" in menu_data["items"][0]["text"]
+
+
+def _assert_no_xss(link_html):
+    """Assert that the rendered link contains no executable HTML."""
+    soup = BeautifulSoup(link_html, "html.parser")
+
+    # no dangerous elements
+    assert soup.find("script") is None
+    assert soup.find("img") is None
+    assert soup.find("svg") is None
+    assert soup.find("iframe") is None
+    assert soup.find("object") is None
+    assert soup.find("embed") is None
+
+    # no event handler attributes anywhere
+    for element in soup.find_all(True):
+        for attr in element.attrs:
+            assert not attr.lower().startswith("on"), (
+                "event handler attribute found: %s" % attr
+            )
+
+    # no dangerous URL protocols in href/src
+    for element in soup.find_all(True):
+        for attr in ("href", "src", "poster"):
+            value = element.get(attr)
+            if value:
+                assert (
+                    not value.lower()
+                    .lstrip()
+                    .startswith(("javascript:", "data:", "vbscript:", "file:"))
+                ), ("dangerous URL protocol in %s" % attr)
+
+
+def test_sidebar_custom_menu_icon_xss(create_app, test_client, req_ctx):
+    """
+    Icons in the sidebar custom menu are rendered as raw HTML; a malicious
+    payload must be neutralized so it cannot execute in a visitor's browser.
+    """
+    payloads = [
+        # event handler on a tag (the reported PoC)
+        "<img src=x onerror=alert('xss')>",
+        "<svg onload=alert('xss')></svg>",
+        # script injection
+        "<script>alert('xss')</script>",
+        # javascript: in an attribute
+        '<a href="javascript:alert(1)">x</a>',
+        # data: URL in an img src
+        '<img src="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">',
+        # attribute breakout trying to inject an event handler
+        '<i class="fas fa-home" onclick="alert(1)"></i>',
+    ]
+
+    for payload in payloads:
+        create_app.config["SIDEBAR_CUSTOM_MENU"] = (
+            '[{"link": "Home", "title": "Home Page", "icon": %s}]'
+            % json.dumps(payload)
+        )
+        menu_data = get_sidebar_menu(test_client)
+        assert menu_data is not None
+        _assert_no_xss(menu_data["items"][0]["html"])
+
+    # the dangerous payload must not appear verbatim anywhere in the page
+    create_app.config["SIDEBAR_CUSTOM_MENU"] = (
+        """[{"link": "Home", "title": "Home Page", "icon": "<img src=x onerror=alert('xss')>"}]"""
+    )
+    rv = test_client.get("/")
+    assert rv.status_code == 200
+    assert "<img src=x onerror=" not in rv.data.decode().lower()
+
+    # legitimate font-awesome icons must still render as HTML
+    create_app.config["SIDEBAR_CUSTOM_MENU"] = (
+        '[{"link": "Home", "title": "Home Page", "icon": %s}]'
+        % json.dumps('<i class="fas fa-home"></i>')
+    )
+    menu_data = get_sidebar_menu(test_client)
+    assert menu_data is not None
+    assert '<i class="fas fa-home"></i>' in menu_data["items"][0]["html"]
 
 
 def test_sidebar_custom_menu_with_separator(create_app, test_client, req_ctx):

--- a/tests/test_sidebar.py
+++ b/tests/test_sidebar.py
@@ -256,6 +256,30 @@ def test_sidebar_custom_menu_icon_xss(create_app, test_client, req_ctx):
     assert '<i class="fas fa-home"></i>' in menu_data["items"][0]["html"]
 
 
+def test_sidebar_custom_menu_icon_allowlist(create_app, test_client, req_ctx):
+    """
+    Icons are sanitized with the allowlist configured for the markdown
+    renderer, so tags allowed there must not be stripped from the sidebar.
+    """
+    icon = '<svg class="icon"><path d="M0 0"></path></svg>'
+    create_app.config["SIDEBAR_CUSTOM_MENU"] = (
+        '[{"link": "Home", "title": "Home Page", "icon": %s}]'
+        % json.dumps(icon)
+    )
+
+    # without the allowlist the icon is escaped
+    create_app.config["RENDERER_HTML_ALLOWLIST"] = ""
+    menu_data = get_sidebar_menu(test_client)
+    assert menu_data is not None
+    assert "<svg" not in menu_data["items"][0]["html"]
+
+    # with svg allowlisted the icon is rendered as html
+    create_app.config["RENDERER_HTML_ALLOWLIST"] = "svg,path[d]"
+    menu_data = get_sidebar_menu(test_client)
+    assert menu_data is not None
+    assert icon in menu_data["items"][0]["html"]
+
+
 def test_sidebar_custom_menu_with_separator(create_app, test_client, req_ctx):
     from otterwiki.sidebar import SidebarMenu
 


### PR DESCRIPTION
Since icons for the menu are being defined as raw HTML, it makes sense to sanitize them with `clean_html()`.